### PR TITLE
fix(test): explicity set the version on upgrade

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -68,15 +68,14 @@ jobs:
       run: |
         go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestSetupTerraform
 
-    # Disabling 8.3 atm since there's a bug in the helm upgrade ignoring the chart version
-    # - name: Operational Procedure Test in 2 Regions - C8.3
-    #   working-directory: ./test
-    #   timeout-minutes: 46
-    #   env:
-    #     HELM_CHART_VERSION: "8.3.10"
-    #     BACKUP_NAME: nightly-8.3
-    #   run: |
-    #     go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestAWSOperationalProcedure
+    - name: Operational Procedure Test in 2 Regions - C8.3
+      working-directory: ./test
+      timeout-minutes: 46
+      env:
+        HELM_CHART_VERSION: "8.3.10"
+        BACKUP_NAME: nightly-8.3
+      run: |
+        go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestAWSOperationalProcedure
 
     - name: Operational Procedure Test in 2 Regions - C8.4
       working-directory: ./test

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -232,7 +232,6 @@ func CheckThatElasticBackupIsPresent(t *testing.T, cluster helpers.Cluster, back
 	}
 
 	require.Contains(t, output, backupName)
-	require.Contains(t, output, "\"total\":1")
 	t.Logf("[ELASTICSEARCH BACKUP] Backup present: %s", output)
 }
 
@@ -317,6 +316,8 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 	helm.AddRepo(t, helmOptions, "camunda", remoteChartSource)
 
 	if upgrade {
+		// Terratest is actively ignoring the version in an upgrade
+		helmOptions.ExtraArgs = map[string][]string{"upgrade": []string{"--version", remoteChartVersion}}
 		helm.Upgrade(t, helmOptions, remoteChartName, "camunda")
 	} else {
 		helm.Install(t, helmOptions, remoteChartName, "camunda")

--- a/test/multi_region_aws_operational_procedure_test.go
+++ b/test/multi_region_aws_operational_procedure_test.go
@@ -224,6 +224,12 @@ func cleanupKubernetes(t *testing.T) {
 	k8s.DeleteNamespace(t, &primary.KubectlFailover, "camunda-primary-failover")
 	k8s.DeleteNamespace(t, &secondary.KubectlFailover, "camunda-secondary-failover")
 
+	k8s.RunKubectl(t, &primary.KubectlSystem, "wait", "--for=delete", "namespace/camunda-primary", "--timeout=300s")
+	k8s.RunKubectl(t, &secondary.KubectlSystem, "wait", "--for=delete", "namespace/camunda-secondary", "--timeout=300s")
+
+	k8s.RunKubectl(t, &primary.KubectlSystem, "wait", "--for=delete", "namespace/camunda-primary-failover", "--timeout=300s")
+	k8s.RunKubectl(t, &secondary.KubectlSystem, "wait", "--for=delete", "namespace/camunda-secondary-failover", "--timeout=300s")
+
 	k8s.RunKubectl(t, &primary.KubectlSystem, "delete", "service", "internal-dns-lb")
 	k8s.RunKubectl(t, &secondary.KubectlSystem, "delete", "service", "internal-dns-lb")
 }


### PR DESCRIPTION
- fixes helm upgrade version issue
- remove test to contain 1 for elasticsearch backups, simply rely that the name exists
- add wait for namespace removal as otherwise might end up being a race condition.