### PR TITLE
chore(test): allow overwriting global tag via env var

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -86,6 +86,26 @@ jobs:
       run: |
         go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestAWSOperationalProcedure
 
+    - name: Operational Procedure Test in 2 Regions - C8.5
+      working-directory: ./test
+      timeout-minutes: 46
+      env:
+        HELM_CHART_VERSION: "9.3.2"
+        BACKUP_NAME: nightly-8.5
+        GLOBAL_IMAGE_TAG: 8.5.0
+      run: |
+        go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestAWSOperationalProcedure
+
+    - name: Operational Procedure Test in 2 Regions - SNAPSHOT
+      working-directory: ./test
+      timeout-minutes: 46
+      env:
+        HELM_CHART_VERSION: "9.3.2"
+        BACKUP_NAME: nightly-SNAPSHOT
+        GLOBAL_IMAGE_TAG: SNAPSHOT
+      run: |
+        go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestAWSOperationalProcedure
+
     - name: Terratest Terraform Teardown
       if: always()
       working-directory: ./test

--- a/test/internal/helpers/helpers.go
+++ b/test/internal/helpers/helpers.go
@@ -75,3 +75,22 @@ func FetchSensitiveTerraformOutput(t *testing.T, options *terraform.Options, nam
 	options.Logger = logger.Discard
 	return terraform.Output(t, options, name)
 }
+
+// Combine two maps into a single map of string key-value pairs
+func CombineMaps(map1, map2 map[string]string) map[string]string {
+	// Create a new map to hold the combined result
+	combined := make(map[string]string)
+
+	// Copy all key-value pairs from map1 to combined map
+	for key, value := range map1 {
+		combined[key] = value
+	}
+
+	// Iterate through map2 and insert key-value pairs into combined map
+	for key, value := range map2 {
+		// If the key already exists in map1, overwrite the value of the existing key
+		combined[key] = value
+	}
+
+	return combined
+}


### PR DESCRIPTION
- Introduces an env var that allows overwriting the global image tag to overwrite the one of the helm chart.
- Add GHA run for C8.5 and SNAPSHOT

Triggered text execution: https://github.com/camunda/c8-multi-region/actions/runs/8570017263
Also tried it out locally to make sure it works.

Definitely, next up is to parallelise everything and split up the test cases as outlined in - https://github.com/camunda/team-infrastructure-experience/issues/179