### PR TITLE
chore(helm): bump to 10.0.1 chart and various temp fixes

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -90,7 +90,7 @@ jobs:
       working-directory: ./test
       timeout-minutes: 46
       env:
-        HELM_CHART_VERSION: "10.0.0"
+        HELM_CHART_VERSION: "10.0.1"
         BACKUP_NAME: nightly-8.5
       run: |
         go test --count=1 -v -timeout 45m ./multi_region_aws_operational_procedure_test.go -run TestAWSOperationalProcedure
@@ -99,7 +99,7 @@ jobs:
       working-directory: ./test
       timeout-minutes: 46
       env:
-        HELM_CHART_VERSION: "10.0.0"
+        HELM_CHART_VERSION: "10.0.1"
         BACKUP_NAME: nightly-SNAPSHOT
         GLOBAL_IMAGE_TAG: SNAPSHOT
       run: |

--- a/aws/dual-region/kubernetes/camunda-values.yml
+++ b/aws/dual-region/kubernetes/camunda-values.yml
@@ -37,6 +37,10 @@ tasklist:
 identity:
   enabled: false
 
+# Temporary Helm chart v10 fix
+identityKeycloak:
+  enabled: false
+
 optimize:
   enabled: false
 
@@ -103,6 +107,11 @@ zeebe-gateway:
     value: "500ms"
   - name: ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_PROBEINTERVAL
     value: "2s"
+  # Temporary Helm chart v10 fix
+  - name: ZEEBE_GATEWAY_NETWORK_HOST
+    value: 0.0.0.0
+  - name: ZEEBE_GATEWAY_NETWORK_PORT
+    value: "26500"
 
   resources:
     requests:
@@ -138,3 +147,13 @@ elasticsearch:
       echo "$S3_SECRET_KEY" | elasticsearch-keystore add -x s3.client.camunda.secret_key
       echo "$S3_ACCESS_KEY" | elasticsearch-keystore add -x s3.client.camunda.access_key
   extraEnvVarsSecret: elasticsearch-env-secret
+  # Bitnami chart fix to allow adding keystore secrets
+  extraVolumeMounts:
+  - name: empty-dir
+    mountPath: /bitnami/elasticsearch
+    subPath: app-volume-dir
+# yamllint disable-line rule:comments-indentation
+  # Fix addition for Helm Chart < 10
+  # extraVolumes:
+  # - name: empty-dir
+  #   emptyDir: {}

--- a/aws/dual-region/scripts/export_environment_prerequisites.sh
+++ b/aws/dual-region/scripts/export_environment_prerequisites.sh
@@ -26,4 +26,4 @@ export CAMUNDA_NAMESPACE_1_FAILOVER=camunda-paris-failover
 
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export HELM_RELEASE_NAME=camunda
-export HELM_CHART_VERSION=10.0.0
+export HELM_CHART_VERSION=10.0.1


### PR DESCRIPTION
Helm chart 10.0.2 hopefully removes the requirement for the temporary fixes

gRPC endpoint was off, keycloak and postgres were deployed by default with identity off

bitnami chart destroyed initScript functionaility