### PR TITLE
chore(renovate): update helm chart and more dependencies

### DIFF
--- a/.github/actions/setup-aws/action.yml
+++ b/.github/actions/setup-aws/action.yml
@@ -15,18 +15,15 @@ runs:
   using: composite
   steps:
   ############# Tool Installations #############
-  - name: gather asdf versions
-    uses: endorama/asdf-parse-tool-versions@v1.3.0
-    id: versions
-  - name: Set up Go environment
-    uses: actions/setup-go@v5
-    with:
-      go-version: ${{ env.GOLANG_VERSION }}
-      cache-dependency-path: "**/go.sum"
-  - name: Set up Terraform
-    uses: hashicorp/setup-terraform@v3
-    with:
-      terraform_version: ${{ env.TERRAFORM_VERSION }}
+  - name: Install tooling using asdf
+    uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6  # v3
+  - name: Print used versions
+    shell: bash
+    run: |
+      asdf current
+      go version
+      helm version
+      terraform version
   ################## Secrets ###################
   - name: Import Secrets
     id: secrets

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -151,7 +151,7 @@
         "\.sh",
         ],
       matchStrings: [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?) registryUrl=(?<registryUrl>.*?)( versioning=(?<versioning>.*?))?\\s.*?(- |=)(?<currentValue>.*)",
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?( versioning=(?<versioning>.*?))?\\s.*?(- |=|: )(?<currentValue>.*)",
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -168,7 +168,7 @@
       fileMatch: ["\.tool-versions$"],
       customType: "regex",
       matchStrings: [
-        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s.* (?<currentValue>.*)\\s"
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s.*? (?<currentValue>.*)\\s"
       ],
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,16 @@
     enabled: true
   },
   packageRules: [
+    {
+      matchPackageNames: ["camunda-platform"],
+      addLabels: ["group:camunda-platform"],
+      groupName: "Camunda Platform",
+    },
+    {
+      matchDatasources: ["go"],
+      addLabels: ["group:go"],
+      groupName: "Go",
+    },
     // limit the PR creation for the Renovate pre-commit hook (it's released very frequently)
     {
       matchPackageNames: ["renovatebot/pre-commit-hooks"],
@@ -131,6 +141,36 @@
         "rhysd/actionlint",
       ],
       extractVersion: "^v(?<version>.*)$",
+    },
+  ],
+  customManagers: [
+    {
+      customType: "regex",
+      fileMatch: [
+        "\.yml",
+        "\.sh",
+        ],
+      matchStrings: [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?) registryUrl=(?<registryUrl>.*?)( versioning=(?<versioning>.*?))?\\s.*?(- |=)(?<currentValue>.*)",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    // Separating Go due to capturing different value with the above statement
+    {
+      customType: "regex",
+      fileMatch: ["\.go"],
+      matchStrings: [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?) registryUrl=(?<registryUrl>.*?)( versioning=(?<versioning>.*?))?\\s.*? \"(?<currentValue>.*)\"",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      fileMatch: ["\.tool-versions$"],
+      customType: "regex",
+      matchStrings: [
+        "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s.* (?<currentValue>.*)\\s"
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },
   ],
 }

--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -5,6 +5,16 @@ on:
   schedule:
   - cron: '0 2 * * 1-5'
   workflow_dispatch:
+  pull_request:
+    # For now limit automatic execution to a minimum, can always be done manually via workflow_dispatch for a branch
+    paths:
+    - 'aws/dual-region/kubernetes/**'
+    - 'aws/dual-region/terraform/**'
+    - '.github/workflows/nightly_aws_operational_procedure.yml'
+
+# limit to a single execution per actor of this workflow
+concurrency:
+  group: "${{ github.workflow }}-${{ github.actor }}"
 
 env:
   AWS_PROFILE: infex

--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -8,9 +8,10 @@ on:
   pull_request:
     # For now limit automatic execution to a minimum, can always be done manually via workflow_dispatch for a branch
     paths:
+    - '.github/workflows/nightly_aws_operational_procedure.yml'
     - 'aws/dual-region/kubernetes/**'
     - 'aws/dual-region/terraform/**'
-    - '.github/workflows/nightly_aws_operational_procedure.yml'
+    - 'test/**'
 
 # limit to a single execution per actor of this workflow
 concurrency:

--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -125,8 +125,11 @@ jobs:
       fail-fast: false
       matrix:
         c8-version:
+        # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^8(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
         - 8.3.11
+        # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^9(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
         - 9.3.3
+        # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^10(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
         - 10.0.2
         - SNAPSHOT
 

--- a/.github/workflows/nightly_aws_region_cleanup.yml
+++ b/.github/workflows/nightly_aws_region_cleanup.yml
@@ -22,6 +22,11 @@ jobs:
     - name: Install tooling using asdf
       uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6  # v3
 
+    - name: Print used versions
+      shell: bash
+      run: |
+        asdf current
+
     - name: Import Secrets
       id: secrets
       uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c  # v3

--- a/.github/workflows/nightly_aws_region_cleanup.yml
+++ b/.github/workflows/nightly_aws_region_cleanup.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
 
+    - name: Install tooling using asdf
+      uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6  # v3
+
     - name: Import Secrets
       id: secrets
       uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c  # v3
@@ -41,8 +44,11 @@ jobs:
 
     - name: Install Cloud Nuke
       run: |
-        wget https://github.com/gruntwork-io/cloud-nuke/releases/download/v0.33.0/cloud-nuke_linux_amd64
+        wget "https://github.com/gruntwork-io/cloud-nuke/releases/download/${CLOUD_NUKE_VERSION}/cloud-nuke_linux_amd64"
         chmod +x cloud-nuke_linux_amd64
+      env:
+        # renovate: datasource=github-tags depName=gruntwork-io/cloud-nuke
+        CLOUD_NUKE_VERSION: v0.35.0
 
     # This is likely to fail, therefore we ignore the error
     # We're ignoring ec2_dhcp_option as they couldn't be deleted

--- a/.github/workflows/scripts/c8_namespace_parser.sh
+++ b/.github/workflows/scripts/c8_namespace_parser.sh
@@ -14,7 +14,7 @@ fi
 
 # For new versions bump -A argument by 1
 # It greps the c8-version and the next x lines
-versions=$(grep 'c8-version:' -A 5 "$1" | awk '/c8-version:/ {flag=1; next} flag {print $2}')
+versions=$(grep 'c8-version:' -A 8 "$1" | awk '/c8-version:/ {flag=1; next} flag {print $2}')
 
 variables=("CLUSTER_0_NAMESPACE" "CLUSTER_1_NAMESPACE" "CLUSTER_0_NAMESPACE_FAILOVER" "CLUSTER_1_NAMESPACE_FAILOVER")
 
@@ -35,8 +35,14 @@ for var in "${variables[@]}"; do
     fi
 
     namespaces=""
+    version_regex="[0-9]+\.[0-9]+\.[0-9]+|SNAPSHOT"
 
     while read -r version; do
+        # Ignore strings that do not match the version regex
+        if ! [[ "$version" =~ $version_regex ]]; then
+            continue
+        fi
+
         if [ "$version" == "SNAPSHOT" ]; then
             version="snapshot"
         fi

--- a/aws/dual-region/scripts/export_environment_prerequisites.sh
+++ b/aws/dual-region/scripts/export_environment_prerequisites.sh
@@ -26,4 +26,5 @@ export CAMUNDA_NAMESPACE_1_FAILOVER=camunda-paris-failover
 
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export HELM_RELEASE_NAME=camunda
+# renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
 export HELM_CHART_VERSION=10.0.2

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
-	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "8.3.11")
+	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "10.0.2")
 	globalImageTag     = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")    // allows overwriting the image tag via GHA of every Camunda image
 	clusterName        = helpers.GetEnv("CLUSTER_NAME", "nightly") // allows supplying random cluster name via GHA
 	backupName         = helpers.GetEnv("BACKUP_NAME", "nightly")  // allows supplying random backup name via GHA

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -26,6 +26,7 @@ const (
 )
 
 var (
+	// renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
 	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "8.3.11")
 	globalImageTag     = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")    // allows overwriting the image tag via GHA of every Camunda image
 	clusterName        = helpers.GetEnv("CLUSTER_NAME", "nightly") // allows supplying random cluster name via GHA


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/180

- finds and parses the c8 helm chart
    - packageRules and customManager weren't working well together, that's why I used custom regex versioning to not bump major versions in certain files
    - install tools via asdf as discussed in the team meeting
    - update cloud-nuke via renovate
    - run the procedure automatically for certain files but limit the execution to maximum 1 per actor
        - e.g. only have one job running of renovate at a time.
        - limited to also just a couple of files, we can always manually execute more if needed or add more if we see it fit