### PR TITLE
chore(gha): use snapshot helm chart for snapshot tests

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -162,6 +162,55 @@ jobs:
       timeout-minutes: 5
       run: |
         go test --count=1 -v -timeout 4m -run TestAWSKubeConfigCreation
+    ########### Snapshot adjustments ##############
+    - name: Pull required secrets
+      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
+      id: secrets
+      uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c  # v3
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/infrastructure-experience/ci/common GITHUB_APP_ID;
+          secret/data/products/infrastructure-experience/ci/common GITHUB_APP_PRIVATE_KEY;
+    - name: Create temporary GitHub App token
+      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
+      uses: actions/create-github-app-token@7bfa3a4717ef143a604ee0a99d859b8886a96d00  # v1
+      id: app-token
+      with:
+        app-id: ${{ steps.secrets.outputs.GITHUB_APP_ID }}
+        private-key: ${{ steps.secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+    - name: Login to GitHub Container Registry
+      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
+      run: |
+        echo ${{ steps.app-token.outputs.token }} | helm registry login ghcr.io -u ${{ steps.secrets.outputs.GITHUB_APP_ID }} --password-stdin
+    - name: Check snapshot chart age
+      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
+      run: |
+        snapshot_age=$(helm show chart oci://ghcr.io/camunda/helm/camunda-platform --version 0.0.0-main-snapshot --debug > /dev/null 2>&1 \
+          | grep -o 'response\.header\.last-modified="[^"]*' \
+          | tail -1)
+        snapshot_age=${snapshot_age#response.header.last-modified=\"}
+
+        # Convert given date to UNIX timestamp
+        given_timestamp=$(date -d "$snapshot_age" +%s)
+        current_timestamp=$(date +%s)
+        difference=$((current_timestamp - given_timestamp))
+
+        # Check if the difference is greater than 72 hours - 3 days (259200 seconds)
+        if [ $difference -gt 259200 ]; then
+          echo "::error ::SNAPSHOT Chart is older than 3 days"
+        fi
+
+        # If the SNAPSHOT is older than 7 days, fail the job
+        if [ $difference -gt 604800 ]; then
+          echo "::error ::SNAPSHOT Chart is older than 7 days"
+          exit 1
+        fi
+
     #### Export required environment variables ####
     - name: Export C8 namespaces and versions
       run: |
@@ -169,10 +218,10 @@ jobs:
         version_with_hyphens="${version//./-}"
 
         if [ "$version" == "SNAPSHOT" ]; then
-          LATEST_HELM_CHART=$(curl -s https://api.github.com/repos/camunda/camunda-platform-helm/releases/latest | jq -r '.tag_name' | sed 's/camunda-platform-//')
           {
             echo "GLOBAL_IMAGE_TAG=SNAPSHOT"
-            echo "HELM_CHART_VERSION=$LATEST_HELM_CHART"
+            echo "HELM_CHART_VERSION=0.0.0-main-snapshot"
+            echo "HELM_CHART_NAME=oci://ghcr.io/camunda/helm/camunda-platform"
             version_with_hyphens="snapshot"
           } >> "$GITHUB_ENV"
         else

--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -163,30 +163,6 @@ jobs:
       run: |
         go test --count=1 -v -timeout 4m -run TestAWSKubeConfigCreation
     ########### Snapshot adjustments ##############
-    - name: Pull required secrets
-      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
-      id: secrets
-      uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c  # v3
-      with:
-        url: ${{ secrets.VAULT_ADDR }}
-        method: approle
-        roleId: ${{ secrets.VAULT_ROLE_ID }}
-        secretId: ${{ secrets.VAULT_SECRET_ID }}
-        exportEnv: false
-        secrets: |
-          secret/data/products/infrastructure-experience/ci/common GITHUB_APP_ID;
-          secret/data/products/infrastructure-experience/ci/common GITHUB_APP_PRIVATE_KEY;
-    - name: Create temporary GitHub App token
-      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
-      uses: actions/create-github-app-token@7bfa3a4717ef143a604ee0a99d859b8886a96d00  # v1
-      id: app-token
-      with:
-        app-id: ${{ steps.secrets.outputs.GITHUB_APP_ID }}
-        private-key: ${{ steps.secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-    - name: Login to GitHub Container Registry
-      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
-      run: |
-        echo ${{ steps.app-token.outputs.token }} | helm registry login ghcr.io -u ${{ steps.secrets.outputs.GITHUB_APP_ID }} --password-stdin
     - name: Check snapshot chart age
       if: ${{ matrix.c8-version == 'SNAPSHOT' }}
       run: |

--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -162,31 +162,6 @@ jobs:
       timeout-minutes: 5
       run: |
         go test --count=1 -v -timeout 4m -run TestAWSKubeConfigCreation
-    ########### Snapshot adjustments ##############
-    - name: Check snapshot chart age
-      if: ${{ matrix.c8-version == 'SNAPSHOT' }}
-      run: |
-        snapshot_age=$(helm show chart oci://ghcr.io/camunda/helm/camunda-platform --version 0.0.0-main-snapshot --debug > /dev/null 2>&1 \
-          | grep -o 'response\.header\.last-modified="[^"]*' \
-          | tail -1)
-        snapshot_age=${snapshot_age#response.header.last-modified=\"}
-
-        # Convert given date to UNIX timestamp
-        given_timestamp=$(date -d "$snapshot_age" +%s)
-        current_timestamp=$(date +%s)
-        difference=$((current_timestamp - given_timestamp))
-
-        # Check if the difference is greater than 72 hours - 3 days (259200 seconds)
-        if [ $difference -gt 259200 ]; then
-          echo "::error ::SNAPSHOT Chart is older than 3 days"
-        fi
-
-        # If the SNAPSHOT is older than 7 days, fail the job
-        if [ $difference -gt 604800 ]; then
-          echo "::error ::SNAPSHOT Chart is older than 7 days"
-          exit 1
-        fi
-
     #### Export required environment variables ####
     - name: Export C8 namespaces and versions
       run: |

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -321,7 +321,9 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 		SetValues:      setValues,
 	}
 
-	helm.AddRepo(t, helmOptions, "camunda", remoteChartSource)
+	if !strings.Contains(remoteChartVersion, "snapshot") {
+		helm.AddRepo(t, helmOptions, "camunda", remoteChartSource)
+	}
 
 	if upgrade {
 		// Terratest is actively ignoring the version in an upgrade

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	remoteChartSource = "https://helm.camunda.io"
-	remoteChartName   = "camunda/camunda-platform"
 
 	resourceDir         = "../aws/dual-region"
 	terraformDir        = "../aws/dual-region/terraform"
@@ -28,9 +27,10 @@ const (
 var (
 	// renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
 	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "10.0.2")
-	globalImageTag     = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")    // allows overwriting the image tag via GHA of every Camunda image
-	clusterName        = helpers.GetEnv("CLUSTER_NAME", "nightly") // allows supplying random cluster name via GHA
-	backupName         = helpers.GetEnv("BACKUP_NAME", "nightly")  // allows supplying random backup name via GHA
+	remoteChartName    = helpers.GetEnv("HELM_CHART_NAME", "camunda/camunda-platform") // allows using OCI registries
+	globalImageTag     = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")                        // allows overwriting the image tag via GHA of every Camunda image
+	clusterName        = helpers.GetEnv("CLUSTER_NAME", "nightly")                     // allows supplying random cluster name via GHA
+	backupName         = helpers.GetEnv("BACKUP_NAME", "nightly")                      // allows supplying random backup name via GHA
 	awsProfile         = helpers.GetEnv("AWS_PROFILE", "infex")
 
 	primary   helpers.Cluster


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/209

uses the oci published snapshot image for the Helm chart for the snapshot image tests.

Tested here: https://github.com/camunda/c8-multi-region/actions/runs/8891867601/job/24416132876
Generally works but due to snapshots more prone to fail, same also failed in the nightly due to Operate not starting up.

```
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66: - name: camunda
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   namespace: snapshot-cluster-0
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   version: 0.0.0-main-snapshot
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   components:
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   - name: Operate
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     id: operate
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     version: SNAPSHOT
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     url: 
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     readiness: [http://camunda-operate.snapshot-cluster-0:80/actuator/health/readiness](http://camunda-operate.snapshot-cluster-0/actuator/health/readiness)
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     metrics: [http://camunda-operate.snapshot-cluster-0:80/actuator/prometheus](http://camunda-operate.snapshot-cluster-0/actuator/prometheus)
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   - name: Tasklist
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     id: tasklist
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     version: SNAPSHOT
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     url: 
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     readiness: [http://camunda-tasklist.snapshot-cluster-0:80/actuator/health/readiness](http://camunda-tasklist.snapshot-cluster-0/actuator/health/readiness)
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     metrics: [http://camunda-tasklist.snapshot-cluster-0:80/actuator/prometheus](http://camunda-tasklist.snapshot-cluster-0/actuator/prometheus)
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   - name: Zeebe Gateway
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     id: zeebeGateway
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     version: SNAPSHOT
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     urls:
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:       grpc: http://
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:       http: http://
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     readiness: http://camunda-zeebe-gateway.snapshot-cluster-0:9600/actuator/health/readiness
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     metrics: http://camunda-zeebe-gateway.snapshot-cluster-0:9600/actuator/prometheus
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:   - name: Zeebe
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     id: zeebe
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     version: SNAPSHOT
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     readiness: http://camunda-zeebe.snapshot-cluster-0:9600/actuator/health/readiness
TestAWSDeployDualRegCamunda/TestDeployC8Helm 2024-04-30T09:17:52Z logger.go:66:     metrics: http://camunda-zeebe.snapshot-cluster-0:9600/actuator/prometheus
```