### PR TITLE
chore(go): disable spot instances and add log dump

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -226,6 +226,18 @@ jobs:
         if [ "$duration" -gt "1500" ]; then
           echo "::error ::Failback of ${{ matrix.c8-version }} is taking longer than 25 minutes"
         fi
+    - name: Debug Step
+      working-directory: ./test
+      if: failure()
+      run: |
+        go test --count=1 -v -timeout 4m -run TestDebugStep
+    - name: Upload Pod Logs
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: pod-logs
+        retention-days: 7
+        path: ./test/*.log
     - name: Cleanup - ${{ matrix.c8-version }}
       working-directory: ./test
       if: always()

--- a/test/internal/helpers/aws/helpers.go
+++ b/test/internal/helpers/aws/helpers.go
@@ -239,10 +239,11 @@ func TestSetupTerraform(t *testing.T, terraformDir, clusterName, awsProfile, tfB
 		TerraformBinary: tfBinary,
 		TerraformDir:    terraformDir,
 		Vars: map[string]interface{}{
-			"cluster_name":      clusterName,
-			"aws_profile":       awsProfile,
-			"np_capacity_type":  "SPOT",
-			"np_instance_types": []string{"m6i.xlarge", "m5.xlarge", "m5d.xlarge"},
+			"cluster_name": clusterName,
+			"aws_profile":  awsProfile,
+			// Disabling spot instances for now since tests have become very flakey
+			// "np_capacity_type":  "SPOT",
+			// "np_instance_types": []string{"m6i.xlarge", "m5.xlarge", "m5d.xlarge"},
 		},
 		NoColor: true,
 	})
@@ -269,10 +270,11 @@ func TestTeardownTerraform(t *testing.T, terraformDir, clusterName, awsProfile, 
 		TerraformBinary: tfBinary,
 		TerraformDir:    terraformDir,
 		Vars: map[string]interface{}{
-			"cluster_name":      clusterName,
-			"aws_profile":       awsProfile,
-			"np_capacity_type":  "SPOT",
-			"np_instance_types": []string{"m6i.xlarge", "m5.xlarge", "m5d.xlarge"},
+			"cluster_name": clusterName,
+			"aws_profile":  awsProfile,
+			// Disabling spot instances for now since tests have become very flakey
+			// "np_capacity_type":  "SPOT",
+			// "np_instance_types": []string{"m6i.xlarge", "m5.xlarge", "m5d.xlarge"},
 		},
 		NoColor: true,
 	})

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -142,6 +142,7 @@ func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
 			cookieAuth = val.Value
 		}
 	}
+	require.NotEmpty(t, cookieAuth)
 
 	// create http client to add cookie to the request
 	client := &http.Client{}


### PR DESCRIPTION
Spot instances are causing some errors that cause too much flakiness.
Eventually environments will become healthy but it takes too much time for the tests to not fail.
It's related to volumes shifting between nodes and zones. If first deployed on zone a but then node recalled, moved to b, the switch takes too long and increasing timeouts is not gonna help.

Additionally, add some log dumps with uploads.