### PR TITLE
chore(gha): disable snapshot till upstream is fixed

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -142,7 +142,7 @@ jobs:
         - 9.3.5
         # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^10(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
         - 10.0.5
-        - SNAPSHOT
+        # - SNAPSHOT
 
     steps:
     ################## Checkout ##################


### PR DESCRIPTION
8.6.0 and the helm chart is not compatible and there is currently no way to fix it.