### PR TITLE
chore(test): adjust latest developments on alpha chart, new csrf token, and global tags

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -168,10 +168,13 @@ jobs:
         version=${{ matrix.c8-version }}
         version_with_hyphens="${version//./-}"
 
+        # SNAPSHOT image = future minor version
+        # SNAPSHOT chart = current minor version
+        # ALPHA chart = future minor version
         if [ "$version" == "SNAPSHOT" ]; then
           {
             echo "GLOBAL_IMAGE_TAG=SNAPSHOT"
-            echo "HELM_CHART_VERSION=0.0.0-main-snapshot"
+            echo "HELM_CHART_VERSION=0.0.0-main-alpha"
             echo "HELM_CHART_NAME=oci://ghcr.io/camunda/helm/camunda-platform"
             version_with_hyphens="snapshot"
           } >> "$GITHUB_ENV"

--- a/test/internal/helpers/helpers.go
+++ b/test/internal/helpers/helpers.go
@@ -94,3 +94,14 @@ func CombineMaps(map1, map2 map[string]string) map[string]string {
 
 	return combined
 }
+
+// Overwrite the image tag for Camunda images in the map with the provided tag
+func OverwriteImageTag(map1 map[string]string, tag string) map[string]string {
+	// Allows to later add additional images to the map like Optimize / Connectors
+	map1["zeebe.image.tag"] = tag
+	map1["zeebeGateway.image.tag"] = tag
+	map1["operate.image.tag"] = tag
+	map1["tasklist.image.tag"] = tag
+
+	return map1
+}

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -136,7 +136,12 @@ func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
 		return
 	}
 
+	csrfTokenName := "OPERATE-X-CSRF-TOKEN"
 	csrfToken := resp.Header.Get("Operate-X-Csrf-Token")
+	if csrfToken == "" {
+		csrfToken = resp.Header.Get("X-Csrf-Token")
+		csrfTokenName = "X-CSRF-TOKEN"
+	}
 
 	var cookieAuth string
 	var csrfTokenId string
@@ -144,7 +149,7 @@ func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
 		if val.Name == "OPERATE-SESSION" {
 			cookieAuth = val.Value
 		}
-		if val.Name == "OPERATE-X-CSRF-TOKEN" {
+		if val.Name == csrfTokenName {
 			csrfTokenId = val.Value
 		}
 	}
@@ -160,8 +165,8 @@ func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
 	req.Header.Add("Content-Type", "application/json")
 	// > 8.5.1, we need to supply the csrf token
 	if csrfTokenId != "" {
-		req.Header.Add("Cookie", fmt.Sprintf("OPERATE-SESSION=%s; OPERATE-X-CSRF-TOKEN=%s", cookieAuth, csrfTokenId))
-		req.Header.Add("OPERATE-X-CSRF-TOKEN", csrfToken)
+		req.Header.Add("Cookie", fmt.Sprintf("OPERATE-SESSION=%s; %s=%s", cookieAuth, csrfTokenName, csrfTokenId))
+		req.Header.Add(csrfTokenName, csrfToken)
 		req.Header.Add("accept", "application/json")
 	} else {
 		req.Header.Add("Cookie", fmt.Sprintf("OPERATE-SESSION=%s", cookieAuth))

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -137,10 +137,10 @@ func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
 	}
 
 	csrfTokenName := "OPERATE-X-CSRF-TOKEN"
-	csrfToken := resp.Header.Get("Operate-X-Csrf-Token")
+	csrfToken := resp.Header.Get(csrfTokenName)
 	if csrfToken == "" {
-		csrfToken = resp.Header.Get("X-Csrf-Token")
 		csrfTokenName = "X-CSRF-TOKEN"
+		csrfToken = resp.Header.Get(csrfTokenName)
 	}
 
 	var cookieAuth string

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -53,11 +53,7 @@ func TestAWSDeployDualRegCamunda(t *testing.T) {
 	if globalImageTag != "" {
 		t.Log("[GLOBAL IMAGE TAG] Overwriting image tag for all Camunda images with " + globalImageTag)
 		// global.image.tag does not overwrite the image tag for all images
-		// therefore we set each image tag individually
-		baseHelmVars["zeebe.image.tag"] = globalImageTag
-		baseHelmVars["zeebeGateway.image.tag"] = globalImageTag
-		baseHelmVars["operate.image.tag"] = globalImageTag
-		baseHelmVars["tasklist.image.tag"] = globalImageTag
+		baseHelmVars = helpers.OverwriteImageTag(baseHelmVars, globalImageTag)
 	}
 
 	parts := strings.Split(remoteChartVersion, ".")
@@ -98,11 +94,7 @@ func TestAWSDualRegFailover(t *testing.T) {
 	if globalImageTag != "" {
 		t.Log("[GLOBAL IMAGE TAG] Overwriting image tag for all Camunda images with " + globalImageTag)
 		// global.image.tag does not overwrite the image tag for all images
-		// therefore we set each image tag individually
-		baseHelmVars["zeebe.image.tag"] = globalImageTag
-		baseHelmVars["zeebeGateway.image.tag"] = globalImageTag
-		baseHelmVars["operate.image.tag"] = globalImageTag
-		baseHelmVars["tasklist.image.tag"] = globalImageTag
+		baseHelmVars = helpers.OverwriteImageTag(baseHelmVars, globalImageTag)
 	}
 
 	parts := strings.Split(remoteChartVersion, ".")
@@ -144,11 +136,7 @@ func TestAWSDualRegFailback(t *testing.T) {
 	if globalImageTag != "" {
 		t.Log("[GLOBAL IMAGE TAG] Overwriting image tag for all Camunda images with " + globalImageTag)
 		// global.image.tag does not overwrite the image tag for all images
-		// therefore we set each image tag individually
-		baseHelmVars["zeebe.image.tag"] = globalImageTag
-		baseHelmVars["zeebeGateway.image.tag"] = globalImageTag
-		baseHelmVars["operate.image.tag"] = globalImageTag
-		baseHelmVars["tasklist.image.tag"] = globalImageTag
+		baseHelmVars = helpers.OverwriteImageTag(baseHelmVars, globalImageTag)
 	}
 
 	parts := strings.Split(remoteChartVersion, ".")

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -52,7 +52,12 @@ func TestAWSDeployDualRegCamunda(t *testing.T) {
 
 	if globalImageTag != "" {
 		t.Log("[GLOBAL IMAGE TAG] Overwriting image tag for all Camunda images with " + globalImageTag)
-		baseHelmVars["global.image.tag"] = globalImageTag
+		// global.image.tag does not overwrite the image tag for all images
+		// therefore we set each image tag individually
+		baseHelmVars["zeebe.image.tag"] = globalImageTag
+		baseHelmVars["zeebeGateway.image.tag"] = globalImageTag
+		baseHelmVars["operate.image.tag"] = globalImageTag
+		baseHelmVars["tasklist.image.tag"] = globalImageTag
 	}
 
 	parts := strings.Split(remoteChartVersion, ".")
@@ -92,7 +97,12 @@ func TestAWSDualRegFailover(t *testing.T) {
 
 	if globalImageTag != "" {
 		t.Log("[GLOBAL IMAGE TAG] Overwriting image tag for all Camunda images with " + globalImageTag)
-		baseHelmVars["global.image.tag"] = globalImageTag
+		// global.image.tag does not overwrite the image tag for all images
+		// therefore we set each image tag individually
+		baseHelmVars["zeebe.image.tag"] = globalImageTag
+		baseHelmVars["zeebeGateway.image.tag"] = globalImageTag
+		baseHelmVars["operate.image.tag"] = globalImageTag
+		baseHelmVars["tasklist.image.tag"] = globalImageTag
 	}
 
 	parts := strings.Split(remoteChartVersion, ".")
@@ -133,7 +143,12 @@ func TestAWSDualRegFailback(t *testing.T) {
 
 	if globalImageTag != "" {
 		t.Log("[GLOBAL IMAGE TAG] Overwriting image tag for all Camunda images with " + globalImageTag)
-		baseHelmVars["global.image.tag"] = globalImageTag
+		// global.image.tag does not overwrite the image tag for all images
+		// therefore we set each image tag individually
+		baseHelmVars["zeebe.image.tag"] = globalImageTag
+		baseHelmVars["zeebeGateway.image.tag"] = globalImageTag
+		baseHelmVars["operate.image.tag"] = globalImageTag
+		baseHelmVars["tasklist.image.tag"] = globalImageTag
 	}
 
 	parts := strings.Split(remoteChartVersion, ".")


### PR DESCRIPTION
closes https://github.com/camunda/c8-multi-region/issues/94 https://github.com/camunda/c8-multi-region/issues/92

I used a local kind cluster to check that everything is working to the degree that it's possible.
The alpha changes on the port changes still have not been merged but I checked that the alpha chart is deployed and the tags are adjusted accordingly.
I also checked that CSRF token is used based on the implementation for this I compared 8.6.0-alpha2 (old csrf token) and SNAPSHOT with the new token. Both worked.

~A successful run remains limited by the alpha adjustments in the helm chat but at least we're prepared when it's done.~

Everything merged and working