### PR TITLE
refactor: update helm chart alpha tag

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -174,7 +174,7 @@ jobs:
         if [ "$version" == "SNAPSHOT" ]; then
           {
             echo "GLOBAL_IMAGE_TAG=SNAPSHOT"
-            echo "HELM_CHART_VERSION=0.0.0-main-alpha"
+            echo "HELM_CHART_VERSION=0.0.0-snapshot-alpha"
             echo "HELM_CHART_NAME=oci://ghcr.io/camunda/helm/camunda-platform"
             version_with_hyphens="snapshot"
           } >> "$GITHUB_ENV"


### PR DESCRIPTION
Because now we use the directory-based structure and all chart versions in the same branch, we renamed the snapshot docker tag to match the new style.