### PR TITLE
chore(gh workflow): concurrency key is now per branch instead of actors

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure.yml
+++ b/.github/workflows/nightly_aws_operational_procedure.yml
@@ -13,9 +13,10 @@ on:
     - 'aws/dual-region/terraform/**'
     - 'test/**'
 
-# limit to a single execution per actor of this workflow
+# limit to a single execution per ref (branch) of this workflow
 concurrency:
-  group: "${{ github.workflow }}-${{ github.actor }}"
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 
 env:
   AWS_PROFILE: infex


### PR DESCRIPTION
With the per actor concurrency check, the same actor triggering CI in two different PRs would have one cancelled in favor of the other. A side of effect of that, is the cancellation does not prevent integration of branch, the tests are just skipped.

Using the reference documentation of github for concurrency, this PR uses the github.ref as the key. The `cancel-in-progress: true` ensures that only the latest version of the commit in the CI is the choosen one.