### PR TITLE
fix: test to use length of brokers compared to ClusterSize

### DIFF
--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -478,7 +478,7 @@ func CheckC8RunningProperly(t *testing.T, primary helpers.Cluster, namespace0, n
 		return
 	}
 
-	require.Equal(t, 8, topology.ClusterSize)
+	require.Equal(t, 8, len(topology.Brokers))
 
 	primaryCount := 0
 	secondaryCount := 0


### PR DESCRIPTION
in the new procedure we're actively decreasing the cluster size, therefore it can never be 8.
Before with zbctl we also used to do length of brokers.

![image](https://github.com/user-attachments/assets/905b7688-ad39-412c-9d70-26ccfd79ffc0)

I guess I thought it would be smarter to just use the cluster size but it's a semi static value in the Zeebe settings and doesn't reflect the actual cluster size but the broker length does.