### PR TITLE
fix: change explicit aws provider version requirement to >= 5.80

### DIFF
--- a/aws/dual-region/terraform/config.tf
+++ b/aws/dual-region/terraform/config.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.80.0"
+      version = ">= 5.80.0"
     }
   }
 }


### PR DESCRIPTION
In the stable 8.6 branch, terraform init fails out of the box due to a conflict in aws provider versions. 
This PR changes an explicit 5.80.0 requirement to >= 5.80.0, resolving the conflict, as a different module requires >=5.81.0