### PR TITLE
fix: rely on helm chart tags instead of overwriting

### DIFF
--- a/.github/workflows/reuseable_aws_operational_procedure.yml
+++ b/.github/workflows/reuseable_aws_operational_procedure.yml
@@ -93,7 +93,9 @@ jobs:
                   # ALPHA chart = future minor version
                   if [ "$version" == "snapshot" ]; then
                   {
-                  echo "GLOBAL_IMAGE_TAG=SNAPSHOT"
+                  # With 8.7 and 8.8 being developed concurrently, the helm chart is 8.7 while the images are 8.8
+                  # Therefore fallback atm on the helm chart defined image tags
+                  # echo "GLOBAL_IMAGE_TAG=SNAPSHOT"
                   echo "HELM_CHART_VERSION=0.0.0-snapshot-alpha"
                   echo "HELM_CHART_NAME=oci://ghcr.io/camunda/helm/camunda-platform"
                   } >> "$GITHUB_ENV"


### PR DESCRIPTION
with 8.7 and 8.8 concurrently being developed we have the issue that snapshot is 8.8 and we try to use that with 8.7 helm chart, therefore rely for now on the 8.7 related image tags defined in the helm chart