### PR TITLE
feat: Partial backport of functions supporting teleport tests stable/8.6

### DIFF
--- a/aws/dual-region/scripts/create_elasticsearch_secrets.sh
+++ b/aws/dual-region/scripts/create_elasticsearch_secrets.sh
@@ -5,12 +5,7 @@ set -e
 create_namespace() {
     local context=$1
     local namespace=$2
-    if kubectl --context "$context" get namespace "$namespace" &> /dev/null; then
-        echo "Namespace $namespace already exists."
-    else
-        # Create the namespace
-        kubectl --context "$context" create namespace "$namespace"
-    fi
+    kubectl --context "$context" create namespace "$namespace" --dry-run=client -o yaml | kubectl --context "$context" apply -f -
 }
 
 create_secret() {

--- a/aws/dual-region/scripts/generate_zeebe_helm_values.sh
+++ b/aws/dual-region/scripts/generate_zeebe_helm_values.sh
@@ -27,6 +27,7 @@ generate_exporter_elasticsearch_url() {
 namespace_0=${CAMUNDA_NAMESPACE_0:-""}
 namespace_1=${CAMUNDA_NAMESPACE_1:-""}
 helm_release_name=${HELM_RELEASE_NAME:-""}
+cluster_size=${ZEEBE_CLUSTER_SIZE:-""}
 
 target_text="in the base Camunda Helm chart values file 'camunda-values.yml'"
 
@@ -40,8 +41,9 @@ fi
 if [ -z "$helm_release_name" ]; then
     read -r -p "Enter Helm release name used for installing Camunda 8 in both Kubernetes clusters: " helm_release_name
 fi
-
-read -r -p "Enter Zeebe cluster size (total number of Zeebe brokers in both Kubernetes clusters): " cluster_size
+if [ -z "$cluster_size" ]; then
+    read -r -p "Enter Zeebe cluster size (total number of Zeebe brokers in both Kubernetes clusters): " cluster_size
+fi
 
 if ((cluster_size % 2 != 0)); then
     echo "Cluster size $cluster_size is an odd number and not supported in a multi-region setup (must be an even number)"

--- a/aws/dual-region/scripts/test_dns_chaining.sh
+++ b/aws/dual-region/scripts/test_dns_chaining.sh
@@ -5,19 +5,14 @@ set -e
 create_namespace() {
     local context=$1
     local namespace=$2
-    if kubectl --context "$context" get namespace "$namespace" &> /dev/null; then
-        echo "Namespace $namespace already exists."
-    else
-        # Create the namespace
-        kubectl --context "$context" create namespace "$namespace"
-    fi
+    kubectl --context "$context" create namespace "$namespace" --dry-run=client -o yaml | kubectl --context "$context" apply -f -
 }
 
 ping_instance() {
     local context=$1
     local source_namespace=$2
     local target_namespace=$3
-    for ((i=1; i<=5; i++))
+    for i in {1..5}
     do
         echo "Iteration $i - $source_namespace -> $target_namespace"
         output=$(kubectl --context "$context" exec -n "$source_namespace" -it sample-nginx -- curl "http://sample-nginx.sample-nginx-peer.$target_namespace.svc.cluster.local")

--- a/test/internal/helpers/helpers.go
+++ b/test/internal/helpers/helpers.go
@@ -32,6 +32,15 @@ func GetEnv(key, fallback string) string {
 	return value
 }
 
+func IsTeleportEnabled() bool {
+	value := GetEnv("TELEPORT", "false")
+	boolVal, err := strconv.ParseBool(value)
+	if err != nil {
+		return false // Default to false if invalid value
+	}
+	return boolVal
+}
+
 func CutOutString(originalString, searchString string) int {
 	re := regexp.MustCompile(searchString)
 	matches := re.FindStringSubmatch(originalString)

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -361,7 +361,17 @@ func createZeebeContactPoints(t *testing.T, size int, namespace0, namespace1 str
 
 func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remoteChartVersion, remoteChartName, remoteChartSource, namespace0, namespace1, namespace0Failover, namespace1Failover string, region int, upgrade, failover, esSwitch bool, setValues map[string]string) {
 
-	if os.Getenv("TELEPORT") != "true" {
+	// Check if TELEPORT is enabled.
+	teleportEnabled := false
+	if teleportStr := os.Getenv("TELEPORT"); teleportStr != "" {
+		var err error
+		teleportEnabled, err = strconv.ParseBool(teleportStr)
+		if err != nil {
+			t.Fatalf("[ELASTICSEARCH] Failed to parse TELEPORT env var: %v", err)
+		}
+	}
+
+	if !teleportEnabled {
 		// Set environment variables for the script
 		os.Setenv("CAMUNDA_NAMESPACE_0", namespace0)
 		os.Setenv("CAMUNDA_NAMESPACE_1", namespace1)

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -22,6 +23,7 @@ import (
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,47 +49,52 @@ type ClusterInfo struct {
 	GatewayVersion    string   `json:"gatewayVersion"`
 }
 
-func CrossClusterCommunication(t *testing.T, withDNS bool, k8sManifests string, primary, secondary helpers.Cluster) {
+func CrossClusterCommunication(t *testing.T, withDNS bool, k8sManifests string, primary, secondary helpers.Cluster, kubeConfigPrimary, kubeConfigSecondary string) {
 	kubeResourcePath := fmt.Sprintf("%s/%s", k8sManifests, "nginx.yml")
 
-	defer k8s.KubectlDelete(t, &primary.KubectlNamespace, kubeResourcePath)
-	defer k8s.KubectlDelete(t, &secondary.KubectlNamespace, kubeResourcePath)
-
-	k8s.KubectlApply(t, &primary.KubectlNamespace, kubeResourcePath)
-	k8s.KubectlApply(t, &secondary.KubectlNamespace, kubeResourcePath)
-
-	k8s.WaitUntilServiceAvailable(t, &primary.KubectlNamespace, "sample-nginx-peer", 10, 5*time.Second)
-	k8s.WaitUntilServiceAvailable(t, &secondary.KubectlNamespace, "sample-nginx-peer", 10, 5*time.Second)
-
-	k8s.WaitUntilPodAvailable(t, &primary.KubectlNamespace, "sample-nginx", 10, 5*time.Second)
-	k8s.WaitUntilPodAvailable(t, &secondary.KubectlNamespace, "sample-nginx", 10, 5*time.Second)
-
-	podPrimary := k8s.GetPod(t, &primary.KubectlNamespace, "sample-nginx")
-	podSecondary := k8s.GetPod(t, &secondary.KubectlNamespace, "sample-nginx")
-
 	if withDNS {
-		// Check if the pods can reach each other via the service
+		primaryNamespaceArr := strings.Split(helpers.GetEnv("CLUSTER_0_NAMESPACE_ARR", ""), ",")
+		secondaryNamespaceArr := strings.Split(helpers.GetEnv("CLUSTER_1_NAMESPACE_ARR", ""), ",")
+		for i := 0; i < len(primaryNamespaceArr); i++ {
+			os.Setenv("CLUSTER_0", primary.ClusterName)
+			os.Setenv("CAMUNDA_NAMESPACE_0", primaryNamespaceArr[i])
+			os.Setenv("CLUSTER_1", secondary.ClusterName)
+			os.Setenv("CAMUNDA_NAMESPACE_1", secondaryNamespaceArr[i])
+			os.Setenv("KUBECONFIG", kubeConfigPrimary+":"+kubeConfigSecondary)
 
-		// wrapped in a for loop since the reload of CoreDNS needs a bit of time to be propagated
-		for i := 0; i < 6; i++ {
-			outputPrimary, errPrimary := k8s.RunKubectlAndGetOutputE(t, &primary.KubectlNamespace, "exec", podPrimary.Name, "--", "curl", "--max-time", "15", fmt.Sprintf("sample-nginx.sample-nginx-peer.%s.svc.cluster.local", secondary.KubectlNamespace.Namespace))
-			outputSecondary, errSecondary := k8s.RunKubectlAndGetOutputE(t, &secondary.KubectlNamespace, "exec", podSecondary.Name, "--", "curl", "--max-time", "15", fmt.Sprintf("sample-nginx.sample-nginx-peer.%s.svc.cluster.local", primary.KubectlNamespace.Namespace))
-			if errPrimary != nil || errSecondary != nil {
-				t.Logf("[CROSS CLUSTER COMMUNICATION] Error: %s", errPrimary)
-				t.Logf("[CROSS CLUSTER COMMUNICATION] Error: %s", errSecondary)
-				t.Log("[CROSS CLUSTER COMMUNICATION] CoreDNS not resolving yet, waiting ...")
-				time.Sleep(15 * time.Second)
-			}
+			output := shell.RunCommandAndGetOutput(t, shell.Command{
+				Command: "sh",
+				Args: []string{
+					"../aws/dual-region/scripts/test_dns_chaining.sh",
+				},
+			})
 
-			if outputPrimary != "" && outputSecondary != "" {
-				t.Logf("[CROSS CLUSTER COMMUNICATION] Success: %s", outputPrimary)
-				t.Logf("[CROSS CLUSTER COMMUNICATION] Success: %s", outputSecondary)
-				t.Log("[CROSS CLUSTER COMMUNICATION] Communication established")
-				break
+			// Check the output for success or failure messages
+			if strings.Contains(output, "Failed to reach the target instance") {
+				t.Fatalf("Script failed: %s", output)
+			} else {
+				t.Logf("Script output: %s", output)
 			}
 		}
+
 	} else {
 		// Check if the pods can reach each other via the IPs directly
+
+		defer k8s.KubectlDelete(t, &primary.KubectlNamespace, kubeResourcePath)
+		defer k8s.KubectlDelete(t, &secondary.KubectlNamespace, kubeResourcePath)
+
+		k8s.KubectlApply(t, &primary.KubectlNamespace, kubeResourcePath)
+		k8s.KubectlApply(t, &secondary.KubectlNamespace, kubeResourcePath)
+
+		k8s.WaitUntilServiceAvailable(t, &primary.KubectlNamespace, "sample-nginx-peer", 10, 5*time.Second)
+		k8s.WaitUntilServiceAvailable(t, &secondary.KubectlNamespace, "sample-nginx-peer", 10, 5*time.Second)
+
+		k8s.WaitUntilPodAvailable(t, &primary.KubectlNamespace, "sample-nginx", 10, 5*time.Second)
+		k8s.WaitUntilPodAvailable(t, &secondary.KubectlNamespace, "sample-nginx", 10, 5*time.Second)
+
+		podPrimary := k8s.GetPod(t, &primary.KubectlNamespace, "sample-nginx")
+		podSecondary := k8s.GetPod(t, &secondary.KubectlNamespace, "sample-nginx")
+
 		podPrimaryIP := podPrimary.Status.PodIP
 		require.NotEmpty(t, podPrimaryIP)
 
@@ -134,15 +141,6 @@ func TeardownC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
 	for _, pvc := range pvcs {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "pvc", pvc.Name)
 	}
-
-	pvs := k8s.ListPersistentVolumes(t, kubectlOptions, metav1.ListOptions{})
-
-	for _, pv := range pvs {
-		if pv.Spec.ClaimRef.Namespace == kubectlOptions.Namespace {
-			k8s.RunKubectl(t, kubectlOptions, "delete", "pv", pv.Name)
-		}
-	}
-
 }
 
 func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
@@ -237,9 +235,38 @@ func RunSensitiveKubectlCommand(t *testing.T, kubectlOptions *k8s.KubectlOptions
 func ConfigureElasticBackup(t *testing.T, cluster helpers.Cluster, clusterName, inputVersion string) {
 	t.Logf("[ELASTICSEARCH] Configuring Elasticsearch backup for cluster %s", cluster.ClusterName)
 
+	// Replace dots with dashes in the version string.
 	version := strings.ReplaceAll(inputVersion, ".", "-")
 
-	output, err := k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--", "curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup", "-H", "Content-Type: application/json", "-d", fmt.Sprintf("{\"type\": \"s3\", \"settings\": {\"bucket\": \"%s-elastic-backup\", \"client\": \"camunda\", \"base_path\": \"%s-backups\"}}", clusterName, version))
+	// Determine if Teleport mode is enabled.
+	teleportEnabled := false
+	if teleportStr, ok := os.LookupEnv("TELEPORT"); ok {
+		if parsed, err := strconv.ParseBool(teleportStr); err == nil {
+			teleportEnabled = parsed
+		} else {
+			t.Fatalf("[ELASTICSEARCH] Failed to parse TELEPORT env var: %v", err)
+		}
+	}
+
+	var output string
+	var err error
+
+	if teleportEnabled {
+		// Teleport mode: use BACKUP_BUCKET and BACKUP_NAME from the environment.
+		output, err = k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--",
+			"curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup",
+			"-H", "Content-Type: application/json",
+			"-d", fmt.Sprintf("{\"type\": \"s3\", \"settings\": {\"bucket\": \"%s\", \"client\": \"camunda\", \"base_path\": \"%s/%s-backups\"}}",
+				os.Getenv("BACKUP_BUCKET"), os.Getenv("BACKUP_NAME"), version))
+	} else {
+		// Default mode: use the provided clusterName and version.
+		output, err = k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--",
+			"curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup",
+			"-H", "Content-Type: application/json",
+			"-d", fmt.Sprintf("{\"type\": \"s3\", \"settings\": {\"bucket\": \"%s-elastic-backup\", \"client\": \"camunda\", \"base_path\": \"%s-backups\"}}",
+				clusterName, version))
+	}
+
 	if err != nil {
 		t.Fatalf("[ELASTICSEARCH] Error: %s", err)
 		return
@@ -335,16 +362,38 @@ func createZeebeContactPoints(t *testing.T, size int, namespace0, namespace1 str
 func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remoteChartVersion, remoteChartName, remoteChartSource, namespace0, namespace1, namespace0Failover, namespace1Failover string, region int, upgrade, failover, esSwitch bool, setValues map[string]string) {
 	zeebeContactPoints := createZeebeContactPoints(t, 4, namespace0, namespace1)
 
+	if os.Getenv("TELEPORT") != "true" {
+		// Set environment variables for the script
+		os.Setenv("CAMUNDA_NAMESPACE_0", namespace0)
+		os.Setenv("CAMUNDA_NAMESPACE_1", namespace1)
+		os.Setenv("HELM_RELEASE_NAME", "camunda")
+		os.Setenv("ZEEBE_CLUSTER_SIZE", "8")
+	}
+
+	// Run the script and capture its output
+	cmd := exec.Command("bash", "../aws/dual-region/scripts/generate_zeebe_helm_values.sh")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("[C8 HELM] Error running script: %v\n", err)
+		return
+	}
+
+	// Convert byte slice to string
+	scriptOutput := string(output)
+
+	// Extract the replacement text for the initial contact points and Elasticsearch URLs
+	initialContact := extractReplacementText(scriptOutput, "ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS")
+	elastic0 := extractReplacementText(scriptOutput, "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCHREGION0_ARGS_URL")
+	elastic1 := extractReplacementText(scriptOutput, "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCHREGION1_ARGS_URL")
+
+	require.NotEmpty(t, initialContact, "Initial contact points should not be empty")
+	require.NotEmpty(t, elastic0, "Elasticsearch region 0 URL should not be empty")
+	require.NotEmpty(t, elastic1, "Elasticsearch region 1 URL should not be empty")
+
 	valuesFiles := []string{"../aws/dual-region/kubernetes/camunda-values.yml"}
 
 	filePath := "../aws/dual-region/kubernetes/camunda-values.yml"
-	if failover {
-		filePath = fmt.Sprintf("../aws/dual-region/kubernetes/region%d/camunda-values-failover.yml", region)
-
-		valuesFiles = append(valuesFiles, filePath)
-	} else {
-		valuesFiles = append(valuesFiles, fmt.Sprintf("../aws/dual-region/kubernetes/region%d/camunda-values.yml", region))
-	}
+	valuesFiles = append(valuesFiles, fmt.Sprintf("../aws/dual-region/kubernetes/region%d/camunda-values.yml", region))
 
 	content, err := os.ReadFile(filePath)
 	if err != nil {
@@ -355,26 +404,10 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 	// Convert byte slice to string
 	fileContent := string(content)
 
-	// Define the template and replacement string
-	template := "PLACEHOLDER"
-
-	// Replace the template with the replacement string
-	modifiedContent := strings.Replace(fileContent, template, zeebeContactPoints, -1)
-
-	// Replace Elasticsearch endpoints with namespace specific ones
-	modifiedContent = strings.Replace(modifiedContent, "http://camunda-elasticsearch-master-hl.camunda-primary.svc.cluster.local:9200", fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace0), -1)
-	modifiedContent = strings.Replace(modifiedContent, "http://camunda-elasticsearch-master-hl.camunda-secondary.svc.cluster.local:9200", fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace1), -1)
-
-	if failover {
-		modifiedContent = strings.Replace(modifiedContent, "http://camunda-elasticsearch-master-hl.camunda-primary-failover.svc.cluster.local:9200", fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace0Failover), -1)
-	}
-
-	if esSwitch && !failover {
-		modifiedContent = strings.Replace(modifiedContent, fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace1), fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace0Failover), -1)
-	}
-	if esSwitch && failover {
-		modifiedContent = strings.Replace(modifiedContent, fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace0Failover), fmt.Sprintf("http://camunda-elasticsearch-master-hl.%s.svc.cluster.local:9200", namespace1), -1)
-	}
+	// Replace the placeholders with the replacement strings
+	modifiedContent := strings.Replace(fileContent, "PLACEHOLDER", initialContact, -1)
+	modifiedContent = strings.Replace(modifiedContent, "http://camunda-elasticsearch-master-hl.camunda-primary.svc.cluster.local:9200", elastic0, -1)
+	modifiedContent = strings.Replace(modifiedContent, "http://camunda-elasticsearch-master-hl.camunda-secondary.svc.cluster.local:9200", elastic1, -1)
 
 	// Write the modified content back to the file
 	err = os.WriteFile(filePath, []byte(modifiedContent), 0644)
@@ -408,6 +441,19 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 		t.Fatalf("[C8 HELM] Error writing file: %v\n", err)
 		return
 	}
+}
+func extractReplacementText(output, variableName string) string {
+	startMarker := fmt.Sprintf("- name: %s\n  value: ", variableName)
+	startIndex := strings.Index(output, startMarker)
+	if startIndex == -1 {
+		return ""
+	}
+	startIndex += len(startMarker)
+	endIndex := strings.Index(output[startIndex:], "\n")
+	if endIndex == -1 {
+		return output[startIndex:]
+	}
+	return output[startIndex : startIndex+endIndex]
 }
 
 func StatefulSetContains(t *testing.T, kubectlOptions *k8s.KubectlOptions, statefulset, searchValue string) bool {
@@ -574,28 +620,6 @@ func DeployC8processAndCheck(t *testing.T, primary helpers.Cluster, secondary he
 	// check that was exported to ElasticSearch and available via Operate
 	CheckOperateForProcesses(t, primary)
 	CheckOperateForProcesses(t, secondary)
-}
-
-func CreateAllNamespaces(t *testing.T, source helpers.Cluster, namespaces, namespacesFailover string) {
-	// Get all namespaces
-	arr := strings.Split(namespaces+","+namespacesFailover, ",")
-
-	for _, ns := range arr {
-		k8s.CreateNamespace(t, &source.KubectlNamespace, ns)
-	}
-}
-
-func CreateAllRequiredSecrets(t *testing.T, source helpers.Cluster, namespaces, namespacesFailover string) {
-	t.Log("[ELASTICSEARCH] Creating AWS Secret for Elasticsearch 🚀")
-
-	S3AWSAccessKey := helpers.GetEnv("S3_AWS_ACCESS_KEY", "")
-	S3AWSSecretAccessKey := helpers.GetEnv("S3_AWS_SECRET_KEY", "")
-
-	arr := strings.Split(namespaces+","+namespacesFailover, ",")
-
-	for _, ns := range arr {
-		RunSensitiveKubectlCommand(t, &source.KubectlNamespace, "create", "--namespace", ns, "secret", "generic", "elasticsearch-env-secret", fmt.Sprintf("--from-literal=S3_SECRET_KEY=%s", S3AWSSecretAccessKey), fmt.Sprintf("--from-literal=S3_ACCESS_KEY=%s", S3AWSAccessKey))
-	}
 }
 
 func DumpAllPodLogs(t *testing.T, kubectlOptions *k8s.KubectlOptions) {

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -360,7 +360,6 @@ func createZeebeContactPoints(t *testing.T, size int, namespace0, namespace1 str
 }
 
 func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remoteChartVersion, remoteChartName, remoteChartSource, namespace0, namespace1, namespace0Failover, namespace1Failover string, region int, upgrade, failover, esSwitch bool, setValues map[string]string) {
-	zeebeContactPoints := createZeebeContactPoints(t, 4, namespace0, namespace1)
 
 	if os.Getenv("TELEPORT") != "true" {
 		// Set environment variables for the script

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -238,20 +238,10 @@ func ConfigureElasticBackup(t *testing.T, cluster helpers.Cluster, clusterName, 
 	// Replace dots with dashes in the version string.
 	version := strings.ReplaceAll(inputVersion, ".", "-")
 
-	// Determine if Teleport mode is enabled.
-	teleportEnabled := false
-	if teleportStr, ok := os.LookupEnv("TELEPORT"); ok {
-		if parsed, err := strconv.ParseBool(teleportStr); err == nil {
-			teleportEnabled = parsed
-		} else {
-			t.Fatalf("[ELASTICSEARCH] Failed to parse TELEPORT env var: %v", err)
-		}
-	}
-
 	var output string
 	var err error
 
-	if teleportEnabled {
+	if helpers.IsTeleportEnabled() {
 		// Teleport mode: use BACKUP_BUCKET and BACKUP_NAME from the environment.
 		output, err = k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--",
 			"curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup",

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -8,7 +8,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -23,7 +22,6 @@ import (
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,36 +47,8 @@ type ClusterInfo struct {
 	GatewayVersion    string   `json:"gatewayVersion"`
 }
 
-func CrossClusterCommunication(t *testing.T, withDNS bool, k8sManifests string, primary, secondary helpers.Cluster, kubeConfigPrimary, kubeConfigSecondary string) {
+func CrossClusterCommunication(t *testing.T, withDNS bool, k8sManifests string, primary, secondary helpers.Cluster) {
 	kubeResourcePath := fmt.Sprintf("%s/%s", k8sManifests, "nginx.yml")
-
-	if withDNS {
-		primaryNamespaceArr := strings.Split(helpers.GetEnv("CLUSTER_0_NAMESPACE_ARR", ""), ",")
-		secondaryNamespaceArr := strings.Split(helpers.GetEnv("CLUSTER_1_NAMESPACE_ARR", ""), ",")
-		for i := 0; i < len(primaryNamespaceArr); i++ {
-			os.Setenv("CLUSTER_0", primary.ClusterName)
-			os.Setenv("CAMUNDA_NAMESPACE_0", primaryNamespaceArr[i])
-			os.Setenv("CLUSTER_1", secondary.ClusterName)
-			os.Setenv("CAMUNDA_NAMESPACE_1", secondaryNamespaceArr[i])
-			os.Setenv("KUBECONFIG", kubeConfigPrimary+":"+kubeConfigSecondary)
-
-			output := shell.RunCommandAndGetOutput(t, shell.Command{
-				Command: "sh",
-				Args: []string{
-					"../aws/dual-region/scripts/test_dns_chaining.sh",
-				},
-			})
-
-			// Check the output for success or failure messages
-			if strings.Contains(output, "Failed to reach the target instance") {
-				t.Fatalf("Script failed: %s", output)
-			} else {
-				t.Logf("Script output: %s", output)
-			}
-		}
-
-	} else {
-		// Check if the pods can reach each other via the IPs directly
 
 	defer k8s.KubectlDelete(t, &primary.KubectlNamespace, kubeResourcePath)
 	defer k8s.KubectlDelete(t, &secondary.KubectlNamespace, kubeResourcePath)
@@ -95,6 +65,29 @@ func CrossClusterCommunication(t *testing.T, withDNS bool, k8sManifests string, 
 	podPrimary := k8s.GetPod(t, &primary.KubectlNamespace, "sample-nginx")
 	podSecondary := k8s.GetPod(t, &secondary.KubectlNamespace, "sample-nginx")
 
+	if withDNS {
+		// Check if the pods can reach each other via the service
+
+		// wrapped in a for loop since the reload of CoreDNS needs a bit of time to be propagated
+		for i := 0; i < 6; i++ {
+			outputPrimary, errPrimary := k8s.RunKubectlAndGetOutputE(t, &primary.KubectlNamespace, "exec", podPrimary.Name, "--", "curl", "--max-time", "15", fmt.Sprintf("sample-nginx.sample-nginx-peer.%s.svc.cluster.local", secondary.KubectlNamespace.Namespace))
+			outputSecondary, errSecondary := k8s.RunKubectlAndGetOutputE(t, &secondary.KubectlNamespace, "exec", podSecondary.Name, "--", "curl", "--max-time", "15", fmt.Sprintf("sample-nginx.sample-nginx-peer.%s.svc.cluster.local", primary.KubectlNamespace.Namespace))
+			if errPrimary != nil || errSecondary != nil {
+				t.Logf("[CROSS CLUSTER COMMUNICATION] Error: %s", errPrimary)
+				t.Logf("[CROSS CLUSTER COMMUNICATION] Error: %s", errSecondary)
+				t.Log("[CROSS CLUSTER COMMUNICATION] CoreDNS not resolving yet, waiting ...")
+				time.Sleep(15 * time.Second)
+			}
+
+			if outputPrimary != "" && outputSecondary != "" {
+				t.Logf("[CROSS CLUSTER COMMUNICATION] Success: %s", outputPrimary)
+				t.Logf("[CROSS CLUSTER COMMUNICATION] Success: %s", outputSecondary)
+				t.Log("[CROSS CLUSTER COMMUNICATION] Communication established")
+				break
+			}
+		}
+	} else {
+		// Check if the pods can reach each other via the IPs directly
 		podPrimaryIP := podPrimary.Status.PodIP
 		require.NotEmpty(t, podPrimaryIP)
 
@@ -141,6 +134,15 @@ func TeardownC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions) {
 	for _, pvc := range pvcs {
 		k8s.RunKubectl(t, kubectlOptions, "delete", "pvc", pvc.Name)
 	}
+
+	pvs := k8s.ListPersistentVolumes(t, kubectlOptions, metav1.ListOptions{})
+
+	for _, pv := range pvs {
+		if pv.Spec.ClaimRef.Namespace == kubectlOptions.Namespace {
+			k8s.RunKubectl(t, kubectlOptions, "delete", "pv", pv.Name)
+		}
+	}
+
 }
 
 func CheckOperateForProcesses(t *testing.T, cluster helpers.Cluster) {
@@ -235,38 +237,9 @@ func RunSensitiveKubectlCommand(t *testing.T, kubectlOptions *k8s.KubectlOptions
 func ConfigureElasticBackup(t *testing.T, cluster helpers.Cluster, clusterName, inputVersion string) {
 	t.Logf("[ELASTICSEARCH] Configuring Elasticsearch backup for cluster %s", cluster.ClusterName)
 
-	// Replace dots with dashes in the version string.
 	version := strings.ReplaceAll(inputVersion, ".", "-")
 
-	// Determine if Teleport mode is enabled.
-	teleportEnabled := false
-	if teleportStr, ok := os.LookupEnv("TELEPORT"); ok {
-		if parsed, err := strconv.ParseBool(teleportStr); err == nil {
-			teleportEnabled = parsed
-		} else {
-			t.Fatalf("[ELASTICSEARCH] Failed to parse TELEPORT env var: %v", err)
-		}
-	}
-
-	var output string
-	var err error
-
-	if teleportEnabled {
-		// Teleport mode: use BACKUP_BUCKET and BACKUP_NAME from the environment.
-		output, err = k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--",
-			"curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup",
-			"-H", "Content-Type: application/json",
-			"-d", fmt.Sprintf("{\"type\": \"s3\", \"settings\": {\"bucket\": \"%s\", \"client\": \"camunda\", \"base_path\": \"%s/%s-backups\"}}",
-				os.Getenv("BACKUP_BUCKET"), os.Getenv("BACKUP_NAME"), version))
-	} else {
-		// Default mode: use the provided clusterName and version.
-		output, err = k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--",
-			"curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup",
-			"-H", "Content-Type: application/json",
-			"-d", fmt.Sprintf("{\"type\": \"s3\", \"settings\": {\"bucket\": \"%s-elastic-backup\", \"client\": \"camunda\", \"base_path\": \"%s-backups\"}}",
-				clusterName, version))
-	}
-
+	output, err := k8s.RunKubectlAndGetOutputE(t, &cluster.KubectlNamespace, "exec", "camunda-elasticsearch-master-0", "--", "curl", "-XPUT", "http://localhost:9200/_snapshot/camunda_backup", "-H", "Content-Type: application/json", "-d", fmt.Sprintf("{\"type\": \"s3\", \"settings\": {\"bucket\": \"%s-elastic-backup\", \"client\": \"camunda\", \"base_path\": \"%s-backups\"}}", clusterName, version))
 	if err != nil {
 		t.Fatalf("[ELASTICSEARCH] Error: %s", err)
 		return
@@ -360,34 +333,7 @@ func createZeebeContactPoints(t *testing.T, size int, namespace0, namespace1 str
 }
 
 func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remoteChartVersion, remoteChartName, remoteChartSource, namespace0, namespace1, namespace0Failover, namespace1Failover string, region int, upgrade, failover, esSwitch bool, setValues map[string]string) {
-
-	if os.Getenv("TELEPORT") != "true" {
-		// Set environment variables for the script
-		os.Setenv("CAMUNDA_NAMESPACE_0", namespace0)
-		os.Setenv("CAMUNDA_NAMESPACE_1", namespace1)
-		os.Setenv("HELM_RELEASE_NAME", "camunda")
-		os.Setenv("ZEEBE_CLUSTER_SIZE", "8")
-	}
-
-	// Run the script and capture its output
-	cmd := exec.Command("bash", "../aws/dual-region/scripts/generate_zeebe_helm_values.sh")
-	output, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("[C8 HELM] Error running script: %v\n", err)
-		return
-	}
-
-	// Convert byte slice to string
-	scriptOutput := string(output)
-
-	// Extract the replacement text for the initial contact points and Elasticsearch URLs
-	initialContact := extractReplacementText(scriptOutput, "ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS")
-	elastic0 := extractReplacementText(scriptOutput, "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCHREGION0_ARGS_URL")
-	elastic1 := extractReplacementText(scriptOutput, "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCHREGION1_ARGS_URL")
-
-	require.NotEmpty(t, initialContact, "Initial contact points should not be empty")
-	require.NotEmpty(t, elastic0, "Elasticsearch region 0 URL should not be empty")
-	require.NotEmpty(t, elastic1, "Elasticsearch region 1 URL should not be empty")
+	zeebeContactPoints := createZeebeContactPoints(t, 4, namespace0, namespace1)
 
 	valuesFiles := []string{"../aws/dual-region/kubernetes/camunda-values.yml"}
 
@@ -462,19 +408,6 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 		t.Fatalf("[C8 HELM] Error writing file: %v\n", err)
 		return
 	}
-}
-func extractReplacementText(output, variableName string) string {
-	startMarker := fmt.Sprintf("- name: %s\n  value: ", variableName)
-	startIndex := strings.Index(output, startMarker)
-	if startIndex == -1 {
-		return ""
-	}
-	startIndex += len(startMarker)
-	endIndex := strings.Index(output[startIndex:], "\n")
-	if endIndex == -1 {
-		return output[startIndex:]
-	}
-	return output[startIndex : startIndex+endIndex]
 }
 
 func StatefulSetContains(t *testing.T, kubectlOptions *k8s.KubectlOptions, statefulset, searchValue string) bool {
@@ -641,6 +574,28 @@ func DeployC8processAndCheck(t *testing.T, primary helpers.Cluster, secondary he
 	// check that was exported to ElasticSearch and available via Operate
 	CheckOperateForProcesses(t, primary)
 	CheckOperateForProcesses(t, secondary)
+}
+
+func CreateAllNamespaces(t *testing.T, source helpers.Cluster, namespaces, namespacesFailover string) {
+	// Get all namespaces
+	arr := strings.Split(namespaces+","+namespacesFailover, ",")
+
+	for _, ns := range arr {
+		k8s.CreateNamespace(t, &source.KubectlNamespace, ns)
+	}
+}
+
+func CreateAllRequiredSecrets(t *testing.T, source helpers.Cluster, namespaces, namespacesFailover string) {
+	t.Log("[ELASTICSEARCH] Creating AWS Secret for Elasticsearch 🚀")
+
+	S3AWSAccessKey := helpers.GetEnv("S3_AWS_ACCESS_KEY", "")
+	S3AWSSecretAccessKey := helpers.GetEnv("S3_AWS_SECRET_KEY", "")
+
+	arr := strings.Split(namespaces+","+namespacesFailover, ",")
+
+	for _, ns := range arr {
+		RunSensitiveKubectlCommand(t, &source.KubectlNamespace, "create", "--namespace", ns, "secret", "generic", "elasticsearch-env-secret", fmt.Sprintf("--from-literal=S3_SECRET_KEY=%s", S3AWSSecretAccessKey), fmt.Sprintf("--from-literal=S3_ACCESS_KEY=%s", S3AWSAccessKey))
+	}
 }
 
 func DumpAllPodLogs(t *testing.T, kubectlOptions *k8s.KubectlOptions) {

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -531,8 +531,8 @@ func recreateCamundaInSecondary_8_6_plus(t *testing.T) {
 		}
 	}
 
-	timeout := "600s"
 	var setValues map[string]string
+	var timeout string = "600s"
 
 	if teleportEnabled {
 		timeout = "1800s"
@@ -542,6 +542,7 @@ func recreateCamundaInSecondary_8_6_plus(t *testing.T) {
 			"tasklist.enabled": "false",
 		}
 	} else {
+		timeout = "600s"
 		setValues = map[string]string{
 		"operate.enabled":  "false",
 		"tasklist.enabled": "false",
@@ -550,7 +551,7 @@ func recreateCamundaInSecondary_8_6_plus(t *testing.T) {
 
 	kubectlHelpers.InstallUpgradeC8Helm(t, &secondary.KubectlNamespace, remoteChartVersion, remoteChartName, remoteChartSource, primaryNamespace, secondaryNamespace, primaryNamespaceFailover, secondaryNamespaceFailover, 1, false, false, false, helpers.CombineMaps(baseHelmVars, setValues))
 
-	k8s.RunKubectl(t, &secondary.KubectlNamespace, "rollout", "status", "--watch", "--timeout=600s", "statefulset/camunda-elasticsearch-master")
+	k8s.RunKubectl(t, &secondary.KubectlNamespace, "rollout", "status", "--watch", "--timeout="+timeout, "statefulset/camunda-elasticsearch-master")
 	// We can't wait for Zeebe to become ready as it's not part of the cluster, therefore out of service 503
 	// We are using instead elastic to become ready as the next steps depend on it, additionally as direct next step we check that the brokers have joined in again.
 }

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -682,7 +682,25 @@ func installWebAppsSecondary(t *testing.T) {
 }
 
 func installWebAppsSecondary_8_6_plus(t *testing.T) {
-	kubectlHelpers.InstallUpgradeC8Helm(t, &secondary.KubectlNamespace, remoteChartVersion, remoteChartName, remoteChartSource, primaryNamespace, secondaryNamespace, primaryNamespaceFailover, secondaryNamespaceFailover, 1, true, false, false, baseHelmVars)
+	// Check if TELEPORT is enabled.
+	teleportEnabled := false
+	if teleportStr := os.Getenv("TELEPORT"); teleportStr != "" {
+		var err error
+		teleportEnabled, err = strconv.ParseBool(teleportStr)
+		if err != nil {
+			t.Fatalf("[ELASTICSEARCH] Failed to parse TELEPORT env var: %v", err)
+		}
+	}
+
+	var setValues map[string]string
+
+	if teleportEnabled {
+		setValues = map[string]string{
+			"zeebe.affinity": "null",
+		}
+	}
+
+	kubectlHelpers.InstallUpgradeC8Helm(t, &secondary.KubectlNamespace, remoteChartVersion, remoteChartName, remoteChartSource, primaryNamespace, secondaryNamespace, primaryNamespaceFailover, secondaryNamespaceFailover, 1, true, false, false, helpers.CombineMaps(baseHelmVars, setValues))
 
 	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-operate", 20, 15*time.Second)
 	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-tasklist", 20, 15*time.Second)

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -348,14 +348,17 @@ func deployC8Helm(t *testing.T) {
 	}
 
 	timeout := "600s"
+	retries := 30
 	var setValues map[string]string
 
 	if teleportEnabled {
 		timeout = "1800s"
+		retries = 100
 		setValues = map[string]string{
 			"zeebe.affinity": "null",
 		}
 	}
+
 
 	// We have to install both at the same time as otherwise zeebe will not become ready
 	kubectlHelpers.InstallUpgradeC8Helm(t, &primary.KubectlNamespace, remoteChartVersion, remoteChartName, remoteChartSource, primaryNamespace, secondaryNamespace, primaryNamespaceFailover, secondaryNamespaceFailover, 0, false, false, false, helpers.CombineMaps(baseHelmVars, setValues))
@@ -367,18 +370,18 @@ func deployC8Helm(t *testing.T) {
 
 	// Elastic itself takes already ~2+ minutes to start
 	// 30 times with 15 seconds sleep = 7,5 minutes
-	k8s.WaitUntilDeploymentAvailable(t, &primary.KubectlNamespace, "camunda-operate", 30, 15*time.Second)
-	k8s.WaitUntilDeploymentAvailable(t, &primary.KubectlNamespace, "camunda-tasklist", 30, 15*time.Second)
-	k8s.WaitUntilDeploymentAvailable(t, &primary.KubectlNamespace, "camunda-zeebe-gateway", 30, 15*time.Second)
+	k8s.WaitUntilDeploymentAvailable(t, &primary.KubectlNamespace, "camunda-operate", retries, 15*time.Second)
+	k8s.WaitUntilDeploymentAvailable(t, &primary.KubectlNamespace, "camunda-tasklist", retries, 15*time.Second)
+	k8s.WaitUntilDeploymentAvailable(t, &primary.KubectlNamespace, "camunda-zeebe-gateway", retries, 15*time.Second)
 
 	// no functions for Statefulsets yet
 	k8s.RunKubectl(t, &primary.KubectlNamespace, "rollout", "status", "--watch", "--timeout="+timeout, "statefulset/camunda-elasticsearch-master")
 	k8s.RunKubectl(t, &primary.KubectlNamespace, "rollout", "status", "--watch", "--timeout="+timeout, "statefulset/camunda-zeebe")
 
 	// 30 times with 15 seconds sleep = 7,5 minutes
-	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-operate", 30, 15*time.Second)
-	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-tasklist", 30, 15*time.Second)
-	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-zeebe-gateway", 30, 15*time.Second)
+	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-operate", retries, 15*time.Second)
+	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-tasklist", retries, 15*time.Second)
+	k8s.WaitUntilDeploymentAvailable(t, &secondary.KubectlNamespace, "camunda-zeebe-gateway", retries, 15*time.Second)
 
 	// no functions for Statefulsets yet
 	k8s.RunKubectl(t, &secondary.KubectlNamespace, "rollout", "status", "--watch", "--timeout="+timeout, "statefulset/camunda-elasticsearch-master")

--- a/test/multi_region_aws_dns_chaining_test.go
+++ b/test/multi_region_aws_dns_chaining_test.go
@@ -1,11 +1,16 @@
 package test
 
 import (
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"multiregiontests/internal/helpers"
 	awsHelpers "multiregiontests/internal/helpers/aws"
 	kubectlHelpers "multiregiontests/internal/helpers/kubectl"
+
+	"github.com/gruntwork-io/terratest/modules/shell"
 )
 
 // Used for creating the global core dns configmap for all versions
@@ -37,18 +42,66 @@ func TestAWSDNSChaining(t *testing.T) {
 }
 
 func TestClusterPrerequisites(t *testing.T) {
-	t.Log("[DNS CHAINING] Running tests for AWS EKS Multi-Region 🚀")
-
-	for _, testFuncs := range []struct {
-		name  string
-		tfunc func(*testing.T)
-	}{
-		{"TestInitKubernetesHelpers", initKubernetesHelpers},
-		{"TestCreateAllNamespaces", testCreateAllNamespaces},
-		{"TestCreateAllRequiredSecrets", testCreateAllRequiredSecrets},
-	} {
-		t.Run(testFuncs.name, testFuncs.tfunc)
+	// Determine if Teleport mode is enabled.
+	teleportEnabled := false
+	if teleportStr, ok := os.LookupEnv("TELEPORT"); ok {
+		if parsed, err := strconv.ParseBool(teleportStr); err == nil {
+			teleportEnabled = parsed
+		} else {
+			t.Fatalf("failed to parse TELEPORT env var: %v", err)
+		}
 	}
+
+	// Log the appropriate test banner.
+	if teleportEnabled {
+		t.Log("[DNS CHAINING] Running tests for AWS EKS Multi-Region through Teleport access 🚀")
+	} else {
+		t.Log("[DNS CHAINING] Running tests for AWS EKS Multi-Region 🚀")
+	}
+
+	// Initialize Kubernetes helpers.
+	t.Run("TestInitKubernetesHelpers", initKubernetesHelpers)
+
+	// Create namespaces and secrets.
+	t.Run("TestCreateAllNamespacesAndSecrets", func(t *testing.T) {
+		t.Log("[K8S] Creating all namespaces and secrets 🚀")
+
+		// Combine primary and failover namespaces.
+		allPrimaryNamespaces := append(
+			strings.Split(primaryNamespaceArr, ","),
+			strings.Split(primaryNamespaceFailoverArr, ",")...,
+		)
+		allSecondaryNamespaces := append(
+			strings.Split(secondaryNamespaceArr, ","),
+			strings.Split(secondaryNamespaceFailoverArr, ",")...,
+		)
+
+		// Ensure both arrays have the same length.
+		if len(allPrimaryNamespaces) != len(allSecondaryNamespaces) {
+			t.Fatal("Primary and secondary namespace arrays must have the same length")
+		}
+
+		// Iterate over namespaces and set environment variables appropriately.
+		for i := range allPrimaryNamespaces {
+			if teleportEnabled {
+				os.Setenv("KUBECONFIG", "./kubeconfig")
+				t.Logf("Primary Namespace: %s, Secondary Namespace: %s", allPrimaryNamespaces[i], allSecondaryNamespaces[i])
+			} else {
+				os.Setenv("KUBECONFIG", kubeConfigPrimary+":"+kubeConfigSecondary)
+				os.Setenv("CLUSTER_0", primary.ClusterName)
+				os.Setenv("CAMUNDA_NAMESPACE_0", allPrimaryNamespaces[i])
+				os.Setenv("CLUSTER_1", secondary.ClusterName)
+				os.Setenv("CAMUNDA_NAMESPACE_1", allSecondaryNamespaces[i])
+			}
+
+			shell.RunCommand(t, shell.Command{
+				Command: "sh",
+				Args: []string{
+					"../aws/dual-region/scripts/create_elasticsearch_secrets.sh",
+				},
+			})
+		}
+	})
 }
 
 func clusterReadyCheck(t *testing.T) {
@@ -59,13 +112,18 @@ func clusterReadyCheck(t *testing.T) {
 
 func testCrossClusterCommunication(t *testing.T) {
 	t.Log("[CROSS CLUSTER] Testing cross-cluster communication with IPs 📡")
-	kubectlHelpers.CrossClusterCommunication(t, false, k8sManifests, primary, secondary)
+	t.Run("TestInitKubernetesHelpers", initKubernetesHelpers)
+
+	kubectlHelpers.CrossClusterCommunication(t, false, k8sManifests, primary, secondary, kubeConfigPrimary, kubeConfigSecondary)
 }
 
 func applyDnsChaining(t *testing.T) {
 	t.Log("[DNS CHAINING] Applying DNS chaining 📡")
-	awsHelpers.DNSChaining(t, primary, secondary, k8sManifests, primaryNamespaceArr, primaryNamespaceFailoverArr)
-	awsHelpers.DNSChaining(t, secondary, primary, k8sManifests, secondaryNamespaceArr, secondaryNamespaceFailoverArr)
+	awsHelpers.CreateLoadBalancers(t, primary, k8sManifests)
+	awsHelpers.CreateLoadBalancers(t, secondary, k8sManifests)
+	allPrimaryNamespaces := primaryNamespaceArr + "," + primaryNamespaceFailoverArr
+	allSecondaryNamespaces := secondaryNamespaceArr + "," + secondaryNamespaceFailoverArr
+	awsHelpers.DNSChaining(t, primary, secondary, k8sManifests, allPrimaryNamespaces, allSecondaryNamespaces)
 }
 
 func testCoreDNSReload(t *testing.T) {
@@ -76,17 +134,6 @@ func testCoreDNSReload(t *testing.T) {
 
 func testCrossClusterCommunicationWithDNS(t *testing.T) {
 	t.Log("[CROSS CLUSTER] Testing cross-cluster communication with DNS 📡")
-	kubectlHelpers.CrossClusterCommunication(t, true, k8sManifests, primary, secondary)
-}
-
-func testCreateAllNamespaces(t *testing.T) {
-	t.Log("[K8S] Creating all namespaces 🚀")
-	kubectlHelpers.CreateAllNamespaces(t, primary, primaryNamespaceArr, primaryNamespaceFailoverArr)
-	kubectlHelpers.CreateAllNamespaces(t, secondary, secondaryNamespaceArr, secondaryNamespaceFailoverArr)
-}
-
-func testCreateAllRequiredSecrets(t *testing.T) {
-	t.Log("[K8S] Creating all required secrets 🚀")
-	kubectlHelpers.CreateAllRequiredSecrets(t, primary, primaryNamespaceArr, primaryNamespaceFailoverArr)
-	kubectlHelpers.CreateAllRequiredSecrets(t, secondary, secondaryNamespaceArr, secondaryNamespaceFailoverArr)
+	t.Run("TestInitKubernetesHelpers", initKubernetesHelpers)
+	kubectlHelpers.CrossClusterCommunication(t, false, k8sManifests, primary, secondary, kubeConfigPrimary, kubeConfigSecondary)
 }

--- a/test/multi_region_aws_dns_chaining_test.go
+++ b/test/multi_region_aws_dns_chaining_test.go
@@ -76,63 +76,30 @@ func TestClusterPrerequisites(t *testing.T) {
 			strings.Split(secondaryNamespaceFailoverArr, ",")...,
 		)
 
-		if teleportEnabled {
-			os.Setenv("KUBECONFIG", "./kubeconfig")
-		
-			// First run with original environment variables
+		// Ensure both arrays have the same length.
+		if len(allPrimaryNamespaces) != len(allSecondaryNamespaces) {
+			t.Fatal("Primary and secondary namespace arrays must have the same length")
+		}
+
+		// Iterate over namespaces and set environment variables appropriately.
+		for i := range allPrimaryNamespaces {
+			if teleportEnabled {
+				os.Setenv("KUBECONFIG", "./kubeconfig")
+				t.Logf("Primary Namespace: %s, Secondary Namespace: %s", allPrimaryNamespaces[i], allSecondaryNamespaces[i])
+			} else {
+				os.Setenv("KUBECONFIG", kubeConfigPrimary+":"+kubeConfigSecondary)
+				os.Setenv("CLUSTER_0", primary.ClusterName)
+				os.Setenv("CAMUNDA_NAMESPACE_0", allPrimaryNamespaces[i])
+				os.Setenv("CLUSTER_1", secondary.ClusterName)
+				os.Setenv("CAMUNDA_NAMESPACE_1", allSecondaryNamespaces[i])
+			}
+
 			shell.RunCommand(t, shell.Command{
 				Command: "sh",
 				Args: []string{
 					"../aws/dual-region/scripts/create_elasticsearch_secrets.sh",
 				},
 			})
-		
-			// Save original values
-			originalNamespace0 := os.Getenv("CAMUNDA_NAMESPACE_0")
-			originalNamespace1 := os.Getenv("CAMUNDA_NAMESPACE_1")
-		
-			// Override environment variables for the second run
-			os.Setenv("CAMUNDA_NAMESPACE_0", os.Getenv("CLUSTER_0_NAMESPACE_FAILOVER"))
-			os.Setenv("CAMUNDA_NAMESPACE_1", os.Getenv("CLUSTER_1_NAMESPACE_FAILOVER"))
-		
-			// Second run with overridden values
-			shell.RunCommand(t, shell.Command{
-				Command: "sh",
-				Args: []string{
-					"../aws/dual-region/scripts/create_elasticsearch_secrets.sh",
-				},
-			})
-		
-			// Restore original environment variables
-			os.Setenv("CAMUNDA_NAMESPACE_0", originalNamespace0)
-			os.Setenv("CAMUNDA_NAMESPACE_1", originalNamespace1)
-		} else {
-
-			// Ensure both arrays have the same length.
-			if len(allPrimaryNamespaces) != len(allSecondaryNamespaces) {
-				t.Fatal("Primary and secondary namespace arrays must have the same length")
-			}
-
-			// Iterate over namespaces and set environment variables appropriately.
-			for i := range allPrimaryNamespaces {
-				if teleportEnabled {
-					os.Setenv("KUBECONFIG", "./kubeconfig")
-					t.Logf("Primary Namespace: %s, Secondary Namespace: %s", allPrimaryNamespaces[i], allSecondaryNamespaces[i])
-				} else {
-					os.Setenv("KUBECONFIG", kubeConfigPrimary+":"+kubeConfigSecondary)
-					os.Setenv("CLUSTER_0", primary.ClusterName)
-					os.Setenv("CAMUNDA_NAMESPACE_0", allPrimaryNamespaces[i])
-					os.Setenv("CLUSTER_1", secondary.ClusterName)
-					os.Setenv("CAMUNDA_NAMESPACE_1", allSecondaryNamespaces[i])
-				}
-
-				shell.RunCommand(t, shell.Command{
-					Command: "sh",
-					Args: []string{
-						"../aws/dual-region/scripts/create_elasticsearch_secrets.sh",
-					},
-				})
-			}
 		}
 	})
 }

--- a/test/multi_region_aws_dns_chaining_test.go
+++ b/test/multi_region_aws_dns_chaining_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -42,18 +41,8 @@ func TestAWSDNSChaining(t *testing.T) {
 }
 
 func TestClusterPrerequisites(t *testing.T) {
-	// Determine if Teleport mode is enabled.
-	teleportEnabled := false
-	if teleportStr, ok := os.LookupEnv("TELEPORT"); ok {
-		if parsed, err := strconv.ParseBool(teleportStr); err == nil {
-			teleportEnabled = parsed
-		} else {
-			t.Fatalf("failed to parse TELEPORT env var: %v", err)
-		}
-	}
-
 	// Log the appropriate test banner.
-	if teleportEnabled {
+	if helpers.IsTeleportEnabled() {
 		t.Log("[DNS CHAINING] Running tests for AWS EKS Multi-Region through Teleport access 🚀")
 	} else {
 		t.Log("[DNS CHAINING] Running tests for AWS EKS Multi-Region 🚀")
@@ -83,7 +72,7 @@ func TestClusterPrerequisites(t *testing.T) {
 
 		// Iterate over namespaces and set environment variables appropriately.
 		for i := range allPrimaryNamespaces {
-			if teleportEnabled {
+			if helpers.IsTeleportEnabled() {
 				os.Setenv("KUBECONFIG", "./kubeconfig")
 				t.Logf("Primary Namespace: %s, Secondary Namespace: %s", allPrimaryNamespaces[i], allSecondaryNamespaces[i])
 			} else {


### PR DESCRIPTION
Backporting these changes should enable teleport tests on main to keep the logic of selecting the appropriate stable branch from the helm chart version being tested. 
This is an MVP that will only support testing the new operational procedure through teleport only.