### PR TITLE
feat: add extra input for the workflow dispatch trigger

### DIFF
--- a/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
@@ -9,6 +9,10 @@ on:
             helm-versions:
                 description: The Helm versions to use as comma separated list
                 type: string
+            notify_back_error_message:
+                description: Error message if retry was not successful. This parameter is used for internal call back actions.
+                required: false
+                default: ''
     pull_request:
         branches-ignore:
             - stable/**

--- a/.github/workflows/nightly_teleport_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_stable.yml
@@ -9,6 +9,10 @@ on:
             helm-versions:
                 description: The Helm versions to use as comma separated list
                 type: string
+            notify_back_error_message:
+                description: Error message if retry was not successful. This parameter is used for internal call back actions.
+                required: false
+                default: ''
     pull_request:
         branches-ignore:
             - stable/**


### PR DESCRIPTION
For testing the automatic workflow retries, infra team's workflow re-run job needs the main branch to be updated with the required inputs first.