### PR TITLE
fix: remove empty-dir addition since its fixed upstream

### DIFF
--- a/.github/workflows/nightly_aws_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_aws_operational_procedure_stable.yml
@@ -155,7 +155,7 @@ jobs:
                   c85=10.5.1
 
                   # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
-                  c86_old=11.2.1
+                  c86_old=11.2.2
                   # for not messing up with renovate, we add the prefix "OLD" in the next step
 
                   # Snapshot is used for namespace setup to do the DNS chaining tests with a static namespace. It's not used for the matrix.

--- a/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
@@ -98,6 +98,8 @@ jobs:
     rerun-failed-jobs:
         if: failure() && fromJSON(github.run_attempt) < 3 && inputs.notify_back_error_message == ''
         runs-on: ubuntu-latest
+        needs:
+            - operational-procedure
         steps:
             - name: Retrigger job
               uses: camunda/infra-global-github-actions/rerun-failed-run@a6261098b91e48a8db1802a58af5191eb498630c # main

--- a/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
@@ -102,7 +102,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@a6261098b91e48a8db1802a58af5191eb498630c # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@66bb8b91caf4c23a1044a67a11c852195d357193 # main at the time of 2025-03-17
               with:
                   error-messages: |
                       PendingPodsError: Found

--- a/.github/workflows/nightly_teleport_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_stable.yml
@@ -38,7 +38,7 @@ jobs:
               id: generate-matrix
               run: |
                   # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io versioning=regex:^11(\.(?<minor>\d+))?(\.(?<patch>\d+))?$
-                  c86=11.2.1
+                  c86=11.2.2
 
                   if [ "${{ inputs.helm-versions }}" == "" ]; then
                     versions='{"helmChartVersion":["'${c86}'"]}'

--- a/aws/dual-region/kubernetes/camunda-values.yml
+++ b/aws/dual-region/kubernetes/camunda-values.yml
@@ -142,8 +142,3 @@ elasticsearch:
             echo "$S3_SECRET_KEY" | elasticsearch-keystore add -x s3.client.camunda.secret_key
             echo "$S3_ACCESS_KEY" | elasticsearch-keystore add -x s3.client.camunda.access_key
     extraEnvVarsSecret: elasticsearch-env-secret
-    # Bitnami chart fix to allow adding keystore secrets
-    extraVolumeMounts:
-        - name: empty-dir
-          mountPath: /bitnami/elasticsearch
-          subPath: app-volume-dir

--- a/aws/dual-region/scripts/export_environment_prerequisites.sh
+++ b/aws/dual-region/scripts/export_environment_prerequisites.sh
@@ -25,4 +25,4 @@ export CAMUNDA_NAMESPACE_1=camunda-paris
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
 export HELM_RELEASE_NAME=camunda
 # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
-export HELM_CHART_VERSION=11.2.1
+export HELM_CHART_VERSION=11.2.2

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	// renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
-	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "11.2.1")
+	remoteChartVersion = helpers.GetEnv("HELM_CHART_VERSION", "11.2.2")
 	remoteChartName    = helpers.GetEnv("HELM_CHART_NAME", "camunda/camunda-platform") // allows using OCI registries
 	globalImageTag     = helpers.GetEnv("GLOBAL_IMAGE_TAG", "")                        // allows overwriting the image tag via GHA of every Camunda image
 	clusterName        = helpers.GetEnv("CLUSTER_NAME", "nightly")                     // allows supplying random cluster name via GHA


### PR DESCRIPTION
The helm chart could not start due to duplicate entries in the resulting manifest.
The bitnami charts finally fixed a required workaround upstream.

Also bumping the 11.2.1 and stable branch to include the fix to work properly.

Related to:

## <small>21.4.7 (2025-02-27)</small>

* [bitnami/elasticsearch] fix: 🐛 Mount emptyDir in /bitnami/elasticsear… (#31607) ([5d7d47f](https://github.com/bitnami/charts/commit/5d7d47f34e21d61c8e117a75dcf8713554140f7b)), closes [#31607](https://github.com/bitnami/charts/issues/31607)
