### PR TITLE
feat: extended helm value override capabilities for teleport runs

### DIFF
--- a/aws/dual-region/kubernetes/teleport-affinities-tolerations.yml
+++ b/aws/dual-region/kubernetes/teleport-affinities-tolerations.yml
@@ -1,0 +1,201 @@
+---
+zeebe:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+operate:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+tasklist:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+identity:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+connectors:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+optimize:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+zeebeGateway:
+    tolerations:
+        - key: t-core-8-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+        - key: t-core-16-unstable
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                    - matchExpressions:
+                          - key: t-core-8-unstable
+                            operator: In
+                            values:
+                                - 'true'
+                    - matchExpressions:
+                          - key: t-core-16-unstable
+                            operator: In
+                            values:
+                                - 'true'
+
+elasticsearch:
+    master:
+        tolerations:
+            - key: t-core-8-unstable
+              operator: Equal
+              value: 'true'
+              effect: NoSchedule
+            - key: t-core-16-unstable
+              operator: Equal
+              value: 'true'
+              effect: NoSchedule
+        affinity:
+            nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                        - matchExpressions:
+                              - key: t-core-8-unstable
+                                operator: In
+                                values:
+                                    - 'true'
+                        - matchExpressions:
+                              - key: t-core-16-unstable
+                                operator: In
+                                values:
+                                    - 'true'

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -384,6 +384,11 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 	filePath := "../aws/dual-region/kubernetes/camunda-values.yml"
 	valuesFiles = append(valuesFiles, fmt.Sprintf("../aws/dual-region/kubernetes/region%d/camunda-values.yml", region))
 
+	if helpers.IsTeleportEnabled() {
+		valuesFiles = append(valuesFiles, "../aws/dual-region/kubernetes/teleport-affinities-tolerations.yml")
+	}
+
+
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("[C8 HELM] Error reading file: %v\n", err)

--- a/test/multi_region_aws_camunda_test.go
+++ b/test/multi_region_aws_camunda_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+
 	"multiregiontests/internal/helpers"
 	kubectlHelpers "multiregiontests/internal/helpers/kubectl"
 
@@ -218,7 +219,6 @@ func deployC8Helm(t *testing.T) {
 	if helpers.IsTeleportEnabled() {
 		timeout = "1800s"
 		retries = 100
-		baseHelmVars["zeebe.affinity"] = "null"
 	}
 
 	// We have to install both at the same time as otherwise zeebe will not become ready
@@ -343,7 +343,6 @@ func recreateCamundaInSecondary_8_6_plus(t *testing.T) {
 
 	if helpers.IsTeleportEnabled() {
 		timeout = "1800s"
-		baseHelmVars["zeebe.affinity"] = "null"
 	}
 
 	kubectlHelpers.InstallUpgradeC8Helm(t, &secondary.KubectlNamespace, remoteChartVersion, remoteChartName, remoteChartSource, primaryNamespace, secondaryNamespace, primaryNamespaceFailover, secondaryNamespaceFailover, 1, false, false, false, helpers.CombineMaps(baseHelmVars, setValues))
@@ -429,9 +428,6 @@ func scaleUpWebApps(t *testing.T) {
 
 func installWebAppsSecondary_8_6_plus(t *testing.T) {
 
-	if helpers.IsTeleportEnabled() {
-		baseHelmVars["zeebe.affinity"] = "null"
-	}
 
 	kubectlHelpers.InstallUpgradeC8Helm(t, &secondary.KubectlNamespace, remoteChartVersion, remoteChartName, remoteChartSource, primaryNamespace, secondaryNamespace, primaryNamespaceFailover, secondaryNamespaceFailover, 1, true, false, false, baseHelmVars)
 


### PR DESCRIPTION
Infra team has upgraded the ci-camunda-eks cluster with additional spot nodepools
This however needs the ability to extensively modify tolerations and affinities for pods deployed during tests through teleport

This PR implements being able to specify larger helm value overrides for teleport runs.