### PR TITLE
chore: switch module source for next version

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -28,7 +28,7 @@ _Nothing referenced yet._
 ### Upstream Dependencies: dependencies of this project
 
 - **terraform-aws-modules**: This project relies on the official AWS modules available at [terraform-aws-modules](https://github.com/terraform-aws-modules).
-- **camunda-tf-eks-module**: This project relies on the Camunda EKS modules available at [camunda-tf-eks-module](https://github.com/camunda/camunda-tf-eks-module/).
+- **camunda-deployment-references**: This project relies on the Camunda EKS modules available at [camunda-deployment-references](https://github.com/camunda/camunda-deployment-references/), which provides an example implementation of an EKS cluster.
 
 ### Downstream Dependencies: things that depend on this project
 

--- a/aws/dual-region/terraform/clusters.tf
+++ b/aws/dual-region/terraform/clusters.tf
@@ -4,7 +4,7 @@
 
 module "eks_cluster_region_0" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/camunda/camunda-tf-eks-module//modules/eks-cluster"
+  source = "github.com/camunda/camunda-deployment-references//aws/modules/eks-cluster"
 
   region                = local.owner.region
   name                  = "${var.cluster_name}-${local.owner.region_full_name}"
@@ -20,7 +20,7 @@ module "eks_cluster_region_0" {
 
 module "eks_cluster_region_1" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/camunda/camunda-tf-eks-module//modules/eks-cluster"
+  source = "github.com/camunda/camunda-deployment-references//aws/modules/eks-cluster"
 
   region                = local.accepter.region
   name                  = "${var.cluster_name}-${local.accepter.region_full_name}"


### PR DESCRIPTION
For "next" (8.7) should switch over to the new repository.