### PR TITLE
fix: switch over to 8.7 snapshot

### DIFF
--- a/.github/workflows/reusable_teleport_operational_procedure.yml
+++ b/.github/workflows/reusable_teleport_operational_procedure.yml
@@ -132,7 +132,7 @@ jobs:
 
                   if [[ $version == "SNAPSHOT" ]]; then
                     {
-                        echo "HELM_CHART_VERSION=0.0.0-snapshot-alpha"
+                        echo "HELM_CHART_VERSION=0.0.0-snapshot-latest"
                         echo "HELM_CHART_NAME=oci://ghcr.io/camunda/helm/camunda-platform"
                     } >> "$GITHUB_ENV"
                     if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then

--- a/.github/workflows/reuseable_aws_operational_procedure.yml
+++ b/.github/workflows/reuseable_aws_operational_procedure.yml
@@ -100,7 +100,7 @@ jobs:
                   # With 8.7 and 8.8 being developed concurrently, the helm chart is 8.7 while the images are 8.8
                   # Therefore fallback atm on the helm chart defined image tags
                   # echo "GLOBAL_IMAGE_TAG=SNAPSHOT"
-                  echo "HELM_CHART_VERSION=0.0.0-snapshot-alpha"
+                  echo "HELM_CHART_VERSION=0.0.0-snapshot-latest"
                   echo "HELM_CHART_NAME=oci://ghcr.io/camunda/helm/camunda-platform"
                   } >> "$GITHUB_ENV"
                   else


### PR DESCRIPTION
`alpha` chart has become `8.8` and is not compatible atm.
Switching to the `8.7` snapshot.

Will merge after everything passed.