### PR TITLE
rename helm release

### DIFF
--- a/.github/workflows/reusable_teleport_operational_procedure.yml
+++ b/.github/workflows/reusable_teleport_operational_procedure.yml
@@ -99,7 +99,9 @@ env:
     KUBECONFIG: ./kubeconfig
 
     BACKUP_BUCKET: ${{ inputs.backupBucket }}
-    HELM_RELEASE_NAME: ${{ inputs.helmReleaseName }}
+
+    CAMUNDA_RELEASE_NAME: ${{ inputs.helmReleaseName }}
+
     ZEEBE_CLUSTER_SIZE: ${{ inputs.zeebeClusterSize }}
     HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
 

--- a/aws/dual-region/scripts/export_environment_prerequisites.sh
+++ b/aws/dual-region/scripts/export_environment_prerequisites.sh
@@ -23,7 +23,8 @@ export CAMUNDA_NAMESPACE_0=camunda-london
 export CAMUNDA_NAMESPACE_1=camunda-paris
 
 # The Helm release name used for installing Camunda 8 in both Kubernetes clusters
-export HELM_RELEASE_NAME=camunda
+export CAMUNDA_RELEASE_NAME=camunda
+
 # renovate: datasource=helm depName=camunda-platform registryUrl=https://helm.camunda.io
 export HELM_CHART_VERSION=12.0.1
 # TODO: [release-duty] before the release, update this!

--- a/aws/dual-region/scripts/generate_zeebe_helm_values.sh
+++ b/aws/dual-region/scripts/generate_zeebe_helm_values.sh
@@ -26,7 +26,7 @@ generate_exporter_elasticsearch_url() {
 
 namespace_0=${CAMUNDA_NAMESPACE_0:-""}
 namespace_1=${CAMUNDA_NAMESPACE_1:-""}
-helm_release_name=${HELM_RELEASE_NAME:-""}
+helm_release_name=${CAMUNDA_RELEASE_NAME:-""}
 cluster_size=${ZEEBE_CLUSTER_SIZE:-""}
 
 target_text="in the base Camunda Helm chart values file 'camunda-values.yml'"

--- a/test/internal/helpers/kubectl/helpers.go
+++ b/test/internal/helpers/kubectl/helpers.go
@@ -355,7 +355,7 @@ func InstallUpgradeC8Helm(t *testing.T, kubectlOptions *k8s.KubectlOptions, remo
 		// Set environment variables for the script
 		os.Setenv("CAMUNDA_NAMESPACE_0", namespace0)
 		os.Setenv("CAMUNDA_NAMESPACE_1", namespace1)
-		os.Setenv("HELM_RELEASE_NAME", "camunda")
+		os.Setenv("CAMUNDA_RELEASE_NAME", "camunda")
 		os.Setenv("ZEEBE_CLUSTER_SIZE", "8")
 	}
 


### PR DESCRIPTION
Following https://github.com/camunda/camunda-deployment-references/pull/250, I'd like to align the CAMUNDA_RELEASE_NAME.

This PR should not be merged before the associated doc pr is approved