### PR TITLE
chore: increase initial pvc for smoother migration to 8.8

### DIFF
--- a/aws/dual-region/kubernetes/camunda-values.yml
+++ b/aws/dual-region/kubernetes/camunda-values.yml
@@ -87,7 +87,7 @@ zeebe:
           value: GZIP
         - name: ZEEBE_BROKER_BACKPRESSURE_AIMD_REQUESTTIMEOUT
           value: 1s
-    pvcSize: 1Gi
+    pvcSize: 32Gi
 
     resources:
         requests:
@@ -130,7 +130,7 @@ elasticsearch:
                 cpu: 1000m
                 memory: 2Gi
         persistence:
-            size: 15Gi
+            size: 30Gi
     initScripts:
         init-keystore.sh: |
             #!/bin/bash


### PR DESCRIPTION
backport of PVC adjustments for a smoother migration as statefulsets are immutable to most parts.
1 GB for Zeebe was too little for 8.8 causing issues, therefore adjusted it for 8.7.

related to https://github.com/camunda/c8-multi-region/pull/764

we can also leave it as is in a separate branch otherwise.