### PR TITLE
fix: only use head ref in PR if base ref matches

### DIFF
--- a/.github/workflows/reusable_teleport_operational_procedure.yml
+++ b/.github/workflows/reusable_teleport_operational_procedure.yml
@@ -183,14 +183,16 @@ jobs:
                       echo "branch=main" >> "$GITHUB_ENV"
                     fi
                   else
-                    if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+                    c8_version=$(curl -X 'GET' -s \
+                    "https://artifacthub.io/api/v1/packages/helm/camunda/camunda-platform/${version}" \
+                    -H "accept: application/json" | jq -r .app_version)
+                    minor_version=$(echo "$c8_version" | cut -d '.' -f 2)
+                    echo "branch=stable/8.${minor_version}" >> "$GITHUB_ENV"
+
+                    # For PRs, overwrite to the head ref if the base ref matches the detected minor version
+                    if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$GITHUB_BASE_REF" =~ 8.${minor_version} ]]; then
+                      echo "Detected PR against matching stable branch, using head ref"
                       echo "branch=$GITHUB_HEAD_REF" >> "$GITHUB_ENV"
-                    else
-                      c8_version=$(curl -X 'GET' -s \
-                      "https://artifacthub.io/api/v1/packages/helm/camunda/camunda-platform/${version}" \
-                      -H "accept: application/json" | jq -r .app_version)
-                      minor_version=$(echo "$c8_version" | cut -d '.' -f 2)
-                      echo "branch=stable/8.$(( minor_version ))" >> "$GITHUB_ENV"
                     fi
                   fi
 


### PR DESCRIPTION
related to https://camunda.slack.com/archives/C03UR0V2R2M/p1759767263504279

- [ ] backport to 8.7 / 8.6

Only overwrite in PRs to the head_ref if the detected minor version is contained in the base ref branch.
So in case of main, the stable checks (that the workflow structure itself works) is still using the value files of minor version branches.
In case of snapshot, we anyway overwrite it to main.

For 8.7 / 8.6 it doesn't matter too much since they can only run the with their own version anyway but can't hurt to backport as it would always match.

```
Determining the checkout info
  /usr/bin/git branch --list --remote origin/stable/8.6
    origin/stable/8.6
```