### PR TITLE
chore(deps): update camunda/infraex-common-config to 2.0.1

### DIFF
--- a/.github/actions/setup-aws/action.yml
+++ b/.github/actions/setup-aws/action.yml
@@ -23,7 +23,7 @@ runs:
 
         ############# Tool Installations #############
         - name: Install asdf tools with cache
-          uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+          uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
 
         - name: Print used versions
           shell: bash

--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
     call-todo-checker:
-        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
     lint:
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/migration_procedure.yml
+++ b/.github/workflows/migration_procedure.yml
@@ -129,7 +129,7 @@ jobs:
             - name: Notify in Slack in case of failure
               id: slack-notification
               if: env.IS_SCHEDULE == 'true'
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_aws_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_aws_operational_procedure_snapshot.yml
@@ -260,7 +260,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_aws_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_aws_operational_procedure_stable.yml
@@ -269,7 +269,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
@@ -92,7 +92,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@317ad657a9766301b0cae99eadfde9dddcffd286 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   error-messages: |
                       PendingPodsError: Found
@@ -112,7 +112,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_teleport_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_stable.yml
@@ -102,7 +102,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@317ad657a9766301b0cae99eadfde9dddcffd286 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@14f6353d2b18d592c390f65c99f75e00c6915234 # main
               with:
                   error-messages: |
                       PendingPodsError: Found
@@ -123,7 +123,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
             exclude: ^test/fixtures/teleport-affinities-tolerations\.yml$
 
     - repo: https://github.com/camunda/infraex-common-config
-      rev: 1.5.9 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+      rev: 2.0.1 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
       hooks:
           - id: update-action-readmes-docker
 


### PR DESCRIPTION
This repository was missed when the other `infraex-common-config` consumers were moved to `2.0.1`. It is still on `1.5.9`, and it will not catch up on its own: `.github/renovate.json5` disables Renovate for everything except the Camunda Helm chart.

```json
{"enabled": false, "matchPackageNames": ["*"]}
```

## Changes

**1. `camunda/infraex-common-config` `1.5.9` -> `2.0.1`** (`4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5`)

8 `uses:` references plus the `.pre-commit-config.yaml` hook.

* Release: https://github.com/camunda/infraex-common-config/releases/tag/2.0.1
* Diff: https://github.com/camunda/infraex-common-config/compare/1.5.9...2.0.1

**2. `camunda/infra-global-github-actions` `317ad657` -> `14f6353d`** (2 references)

`317ad657` dates from 2026-02-07 and predates that repository's own SHA pinning, so its action tree still resolves unpinned references. GitHub evaluates the pinning requirement over the **entire** dependency tree at `Set up job`, so in a repository where that setting is on, runs are refused before any step executes and the caller cannot work around it. Sibling repositories have already hit this. `14f6353d` is the current `main` and the revision where those actions became SHA-pinned.

## Validation

`actionlint` (v1.7.10, the pinned hook version) passes on all 7 modified workflows. `yamllint`, `yamlfmt`, `update-action-readmes` and the whitespace hooks pass on the full changeset.

## Not in scope

`stable/8.4` through `stable/8.8` still carry `1.3.9`/`1.5.9`. Renovate does not target them either: `baseBranchPatterns` is not set, so only the default branch is processed.