### PR TITLE
ci: re-pin infra-global-github-actions to its SHA-pinned revision

### DIFF
--- a/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
@@ -92,7 +92,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   error-messages: |
                       PendingPodsError: Found

--- a/.github/workflows/nightly_teleport_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_stable.yml
@@ -102,7 +102,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@14f6353d2b18d592c390f65c99f75e00c6915234 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   error-messages: |
                       PendingPodsError: Found


### PR DESCRIPTION
Re-pins `camunda/infra-global-github-actions` to `3ec04ae6fd02074f0253dedf6850bb9b50eb59d3`, the merge commit of camunda/infra-global-github-actions#781.

That PR pins every action in the dependency tree of those composite actions, **including the `actions/*` namespace**. GitHub's **Require actions to be pinned to a full-length commit SHA** grants no namespace exemption:

> all actions must be pinned to a full-length commit SHA to be used. This includes actions from your organization and actions authored by GitHub.

It is evaluated over the **whole** dependency tree at `Set up job`, so until now no revision a caller could pick would have helped — the fix had to happen upstream.

Verified at `3ec04ae6`: the dependency tree of every composite action this repository consumes resolves to SHA pins only.

Affects 2 references, both `rerun-failed-run` in the nightly Teleport procedures. #953 could not unblock them: `rerun-failed-run` resolved `hashicorp/vault-action@v4.0.0`, `actions/create-github-app-token@v3` and `codex-/return-dispatch@v3`, none of which a caller could pin from here.

Renovate will not do this bump on its own in this repository: `.github/renovate.json5` disables it for every package except the Camunda Helm chart.