### PR TITLE
chore(deps): update camunda/infraex-common-config to 2.0.1

### DIFF
--- a/.github/actions/setup-aws/action.yml
+++ b/.github/actions/setup-aws/action.yml
@@ -19,7 +19,7 @@ runs:
 
         ############# Tool Installations #############
         - name: Install asdf tools with cache
-          uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@c585602ff49e32c4c3b2dc4be1d7e7a0017961db # 1.3.9
+          uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
 
         - name: Print used versions
           shell: bash

--- a/.github/workflows/internal_global_pr_todo_checker.yml
+++ b/.github/workflows/internal_global_pr_todo_checker.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
     call-todo-checker:
-        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+        uses: camunda/infraex-common-config/.github/workflows/todo-checker-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
     lint:
-        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@c585602ff49e32c4c3b2dc4be1d7e7a0017961db # 1.3.9
+        uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.github/workflows/nightly_aws_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_aws_operational_procedure_snapshot.yml
@@ -271,7 +271,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@c585602ff49e32c4c3b2dc4be1d7e7a0017961db # 1.3.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_aws_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_aws_operational_procedure_stable.yml
@@ -264,7 +264,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@c585602ff49e32c4c3b2dc4be1d7e7a0017961db # 1.3.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_snapshot.yml
@@ -103,7 +103,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@317ad657a9766301b0cae99eadfde9dddcffd286 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   error-messages: |
                       PendingPodsError: Found
@@ -123,7 +123,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@c585602ff49e32c4c3b2dc4be1d7e7a0017961db # 1.3.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/nightly_teleport_operational_procedure_stable.yml
+++ b/.github/workflows/nightly_teleport_operational_procedure_stable.yml
@@ -101,7 +101,7 @@ jobs:
             - operational-procedure
         steps:
             - name: Retrigger job
-              uses: camunda/infra-global-github-actions/rerun-failed-run@317ad657a9766301b0cae99eadfde9dddcffd286 # main
+              uses: camunda/infra-global-github-actions/rerun-failed-run@66bf6e260f2beb42a83284fef490bb96672e8f36 # main
               with:
                   error-messages: |
                       PendingPodsError: Found
@@ -122,7 +122,7 @@ jobs:
         steps:
             - name: Notify in Slack in case of failure
               id: slack-notification
-              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@c585602ff49e32c4c3b2dc4be1d7e7a0017961db # 1.3.9
+              uses: camunda/infraex-common-config/.github/actions/report-failure-on-slack@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
               with:
                   vault_addr: ${{ secrets.VAULT_ADDR }}
                   vault_role_id: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -16,5 +16,5 @@ concurrency:
 
 jobs:
     renovate-automerge:
-        uses: camunda/infraex-common-config/.github/workflows/automerge-global.yml@193a21e1e56c9a65517a822224ac3b4ffa4d6ae4 # 1.5.9
+        uses: camunda/infraex-common-config/.github/workflows/automerge-global.yml@4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5 # 2.0.1
         secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
           - id: yamlfmt
 
     - repo: https://github.com/camunda/infraex-common-config
-      rev: 1.3.9 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
+      rev: 2.0.1 # use tags until renovate supports sha: https://github.com/renovatebot/renovate/issues/22567
       hooks:
           - id: update-action-readmes-docker
 


### PR DESCRIPTION
Brings this maintenance branch in line with `main` (#953) and the rest of the fleet.

## Changes

**1. `camunda/infraex-common-config` -> `2.0.1`** (`4e5ecdb4100b2a50e46b3517cc8c285c80f7ccd5`), covering every `uses:` reference and the `.pre-commit-config.yaml` hook.

* Release: https://github.com/camunda/infraex-common-config/releases/tag/2.0.1

**2. `camunda/infra-global-github-actions` `317ad657` -> `66bf6e26`**

`317ad657` dates from 2026-02-07 and predates that repository's own SHA pinning, so its action tree still resolved unpinned references. GitHub's **Require actions to be pinned to a full-length commit SHA** grants no namespace exemption and is evaluated over the **whole** dependency tree at `Set up job`, so the job is refused before any step runs and no revision a caller could pick would have helped. `66bf6e26` is the current `main` of that repository, where the entire tree is pinned (camunda/infra-global-github-actions#781, #783).

## Why this needs a manual PR

Renovate will not do either update on this branch, for two independent reasons:

```json
{"enabled": false, "matchPackageNames": ["*"]}
```

It is disabled for every package except the Camunda Helm chart. And `baseBranchPatterns` is not set, so Renovate only ever processes the default branch — this branch is invisible to it regardless.

## Verification

- No residual revision: every reference resolves to `4e5ecdb4` or `66bf6e26`.
- `actionlint` exits 0 on the modified workflows.
